### PR TITLE
5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Fixed a small bug which caused the image anchor setting to be applied only to the active participants and not to the other thumbnails.
+
 ## 5.0.0
 
 Version 5.0.0 brings a lot of changes and reworks to the internal code of the module to make it more modular and easy to understand (the first update of several), while also bringing a brand new feature and several bug fixes and UI improvements.

--- a/css/active-conversation/active-participant.css
+++ b/css/active-conversation/active-participant.css
@@ -146,7 +146,6 @@
 
   background-color: rgba(0, 0, 0, 0.65);
   border-top: 1px solid var(--color-border-dark);
-  border-radius: 0px 0px 15px 15px;
 }
 /* #endregion */
 

--- a/templates/conversation.hbs
+++ b/templates/conversation.hbs
@@ -34,7 +34,7 @@
               draggable="true"
               onclick="game.ConversationHud.changeActiveParticipant({{index}})"
             >
-              <img class="portrait" src="{{participant.img}}" alt="Portrait" />
+              <img class="portrait {{../portraitAnchor}}" src="{{participant.img}}" alt="Portrait" />
               <p class="name">{{participant.name}}</p>
             </div>
 
@@ -52,7 +52,7 @@
         <div class="conversation-participant-wrapper">
           {{!-- Participant --}}
           <div class="conversation-participant" data-tooltip="{{participant.name}}">
-            <img class="portrait" src="{{participant.img}}" alt="image" />
+            <img class="portrait {{../portraitAnchor}}" src="{{participant.img}}" alt="image" />
             <p class="name">{{participant.name}}</p>
           </div>
 


### PR DESCRIPTION
- Fixed a small bug which caused the image anchor setting to be applied only to the active participants and not to the other thumbnails (#17).