### PR TITLE
Release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.1.0
+
+- Added the option to select a participant that will be enabled by default when a conversation is started
+- Added the option to link journal entries to participants (MEJ entries supported)
+- Added an additional button to the conversation controls that closes the currently active conversation
+- Added confirmation dialogues when trying to close an active conversation or when trying to delete a participant in an active conversation
+- Fixed an issue which caused UI elements to overflow when using the top or bottom position for the camera dock
+- Fixed an issue which caused the conversation sheet display to close before the user could confirm if they wanted to keep or discard the unsaved changes (affected MEJ users only)
+- Small UX and UI improvements
+
 ## 5.0.2
 
 - Fixed a bug that caused the faction of the active participant to not be hidden when conversation visibility was toggled off

--- a/css/active-conversation/controls.css
+++ b/css/active-conversation/controls.css
@@ -49,7 +49,15 @@
   box-shadow: 0 0 10px #9b8dff;
 }
 
-#ui-conversation-controls .control-button.margin {
+#ui-conversation-controls .control-button.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+#ui-conversation-controls .control-button.margin-top {
   margin-top: 30px;
+}
+#ui-conversation-controls .control-button.margin-bottom {
+  margin-bottom: 30px;
 }
 /* #endregion */

--- a/css/active-conversation/participants-list.css
+++ b/css/active-conversation/participants-list.css
@@ -7,6 +7,8 @@
   margin-left: 50px;
 
   height: 100%;
+  max-height: 700px;
+
   overflow-y: auto;
   padding: 10px;
 }

--- a/css/active-conversation/responsiveness.css
+++ b/css/active-conversation/responsiveness.css
@@ -47,4 +47,11 @@
     display: none;
   }
 }
+
+@media only screen and (max-height: 960px) {
+  /* CSS rules to make sure that the conversation hud displays properly when using the camera dock on the top or bottom */
+  .conversation-hud-content.has-dock .active-participant.vertical {
+    width: 18vw;
+  }
+}
 /* #endregion */

--- a/css/active-conversation/wrapper.css
+++ b/css/active-conversation/wrapper.css
@@ -32,8 +32,7 @@
   justify-content: center;
   align-items: center;
 
-  height: 65vh;
-  max-height: 650px;
+  height: 100%;
 
   pointer-events: all;
 }
@@ -48,17 +47,11 @@
 
 /* ----- Conversation minimized ----- */
 /* #region */
-.conversation-hud-wrapper.minimized {
-  height: 100%;
-}
-
 .conversation-hud-wrapper.minimized .conversation-hud-content {
   flex-direction: column;
   align-items: flex-end;
   justify-content: space-between;
   margin-right: 10px;
-  height: 100%;
-  max-height: calc(100vh - 54px - 62px);
 }
 
 /* Active participant */
@@ -112,6 +105,7 @@
 
 /* Participant list */
 .conversation-hud-wrapper.minimized .conversation-participant-list {
+  max-height: unset;
   margin-top: 25px;
   margin-bottom: 25px;
 }

--- a/css/conversation-entry-sheet/participant-list.css
+++ b/css/conversation-entry-sheet/participant-list.css
@@ -1,3 +1,37 @@
+.conversation-entry-sheet .participants-list-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.conversation-entry-sheet .participants-list-header p {
+  margin: 0;
+  font-size: 12px;
+  text-align: center;
+  font-weight: bold;
+  color: var(--color-text-dark-secondary);
+}
+
+.conversation-entry-sheet .participants-list-header .active-by-default {
+  margin-left: 28px;
+}
+
+.conversation-entry-sheet .participants-list-header .faction {
+  margin-left: 14px;
+}
+
+.conversation-entry-sheet .participants-list-header .details {
+  margin-left: 14px;
+}
+
+.conversation-entry-sheet .participants-list-header .controls {
+  margin-left: auto;
+  margin-right: 24px;
+}
+
 .conversation-entry-sheet .participants-list {
   display: flex;
   flex-flow: column;

--- a/css/conversation-entry-sheet/participant.css
+++ b/css/conversation-entry-sheet/participant.css
@@ -56,8 +56,8 @@
 /* ----- Portrait Display ----- */
 /* #region */
 .conversation-entry-sheet .portrait-wrapper {
-  height: 40px;
-  width: 40px;
+  height: 44px;
+  width: 44px;
   margin-left: 15px;
 
   border: 1px solid var(--color-border-dark);
@@ -94,6 +94,16 @@
   margin: 0;
   font-style: italic;
   font-size: 11px;
+}
+
+.conversation-entry-sheet .text-wrapper .linked-journal {
+  margin: 0;
+  margin-top: 6px;
+  font-size: 11px;
+}
+
+.conversation-entry-sheet .text-wrapper .linked-journal a {
+  color: var(--color-text-hyperlink);
 }
 /* #endregion */
 

--- a/css/conversation-entry-sheet/participant.css
+++ b/css/conversation-entry-sheet/participant.css
@@ -8,6 +8,13 @@
 }
 /* #endregion */
 
+/* ----- Active bu default checkbox ----- */
+/* #region */
+.conversation-entry-sheet #participant-active-by-default {
+  margin-right: 20px;
+}
+/* #endregion */
+
 /* ----- Faction Display ----- */
 /* #region */
 .conversation-entry-sheet .faction-wrapper {
@@ -51,7 +58,7 @@
 .conversation-entry-sheet .portrait-wrapper {
   height: 40px;
   width: 40px;
-  margin-left: 5px;
+  margin-left: 15px;
 
   border: 1px solid var(--color-border-dark);
   border-radius: 3px;

--- a/css/misc.css
+++ b/css/misc.css
@@ -8,4 +8,6 @@
 
 #ui-middle > #ui-conversation-hud {
   z-index: 20;
+  flex: 1;
+  min-height: 0;
 }

--- a/js/controls.js
+++ b/js/controls.js
@@ -10,7 +10,11 @@ Hooks.on("getSceneControlButtons", (controls) => {
         active: game.ConversationHud.conversationIsActive,
         visible: game.user.isGM,
         onClick: (toggle) => {
-          Hooks.call("toggleConversation", toggle);
+          if (toggle) {
+            game.ConversationHud.onToggleConversation(true);
+          } else {
+            game.ConversationHud.handleCloseActiveConversation();
+          }
         },
         button: true,
       });

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -13,6 +13,7 @@ import {
   getDragAndDropIndex,
   setDefaultDataForParticipant,
   getConfirmationFromUser,
+  checkIfCameraDockOnBottomOrTop,
 } from "./helpers.js";
 import { socket } from "./init.js";
 import { MODULE_NAME } from "./constants.js";
@@ -78,6 +79,7 @@ export class ConversationHud {
 
     // Render templates
     const renderedHtml = await renderTemplate("modules/conversation-hud/templates/conversation.hbs", {
+      hasDock: checkIfCameraDockOnBottomOrTop(),
       participants: conversationData.participants,
       isGM: game.user.isGM,
       portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),
@@ -289,6 +291,7 @@ export class ConversationHud {
 
     // Render template
     const renderedHtml = await renderTemplate("modules/conversation-hud/templates/conversation.hbs", {
+      hasDock: checkIfCameraDockOnBottomOrTop(),
       participants: conversationData.participants,
       isGM: game.user.isGM,
       portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -419,19 +419,21 @@ export class ConversationHud {
         return;
       }
 
-      // Check to see if the removed participant is the active one
-      // Otherwise, check to see if the removed participant is before the active one, in which case
-      // we need to update the active participant index by lowering it by one
-      if (game.ConversationHud.activeConversation.activeParticipant === index) {
-        game.ConversationHud.activeConversation.activeParticipant = -1;
-      } else if (index < game.ConversationHud.activeConversation.activeParticipant) {
-        game.ConversationHud.activeConversation.activeParticipant -= 1;
-      }
+      getConfirmationFromUser("CHUD.dialogue.onRemoveParticipant", () => {
+        // Check to see if the removed participant is the active one
+        // Otherwise, check to see if the removed participant is before the active one, in which case
+        // we need to update the active participant index by lowering it by one
+        if (game.ConversationHud.activeConversation.activeParticipant === index) {
+          game.ConversationHud.activeConversation.activeParticipant = -1;
+        } else if (index < game.ConversationHud.activeConversation.activeParticipant) {
+          game.ConversationHud.activeConversation.activeParticipant -= 1;
+        }
 
-      // Remove participant with the given index
-      game.ConversationHud.activeConversation.participants.splice(index, 1);
+        // Remove participant with the given index
+        game.ConversationHud.activeConversation.participants.splice(index, 1);
 
-      socket.executeForEveryone("updateActiveConversation", game.ConversationHud.activeConversation);
+        socket.executeForEveryone("updateActiveConversation", game.ConversationHud.activeConversation);
+      });
     }
   }
 

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -624,17 +624,21 @@ export class ConversationHud {
   async renderJournalSheet(journalId) {
     let journal = game.journal.get(journalId);
 
-    // Handler for MEJ so that the referenced document is displayed in a separate popup sheet and not the regular MEJ journal
-    if (game.modules.get("monks-enhanced-journal")?.active) {
-      if (game.MonksEnhancedJournal.getMEJType(journal)) {
-        if (journal instanceof JournalEntry) {
-          journal = journal.pages.contents[0];
+    if (!journal) {
+      ui.notifications.error(game.i18n.localize("CHUD.errors.invalidJournalEntry"));
+    } else {
+      // Handler for MEJ so that the referenced document is displayed in a separate popup sheet and not the regular MEJ journal
+      if (game.modules.get("monks-enhanced-journal")?.active) {
+        if (game.MonksEnhancedJournal.getMEJType(journal)) {
+          if (journal instanceof JournalEntry) {
+            journal = journal.pages.contents[0];
+          }
+          game.MonksEnhancedJournal.fixType(journal);
         }
-        game.MonksEnhancedJournal.fixType(journal);
       }
-    }
 
-    journal.sheet.render(true);
+      journal.sheet.render(true);
+    }
   }
 
   async #handleSaveConversation(data) {

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -12,6 +12,7 @@ import {
   displayDragAndDropIndicator,
   getDragAndDropIndex,
   setDefaultDataForParticipant,
+  getConfirmationFromUser,
 } from "./helpers.js";
 import { socket } from "./init.js";
 import { MODULE_NAME } from "./constants.js";
@@ -29,9 +30,6 @@ export class ConversationHud {
 
     this.dropzoneVisible = false;
     this.draggingParticipant = false;
-
-    // Register local hooks
-    Hooks.on("toggleConversation", this.onToggleConversation.bind(this));
 
     // Register socket hooks
     this.registerSocketFunctions();
@@ -404,6 +402,13 @@ export class ConversationHud {
         });
       }
     }
+  }
+
+  // Function that handles conversation being closed
+  handleCloseActiveConversation() {
+    getConfirmationFromUser("CHUD.dialogue.onCloseActiveConversation", () => {
+      game.ConversationHud.onToggleConversation(false);
+    });
   }
 
   // Function that removes a participant from the active conversation

--- a/js/conversationEntrySheet.js
+++ b/js/conversationEntrySheet.js
@@ -16,19 +16,33 @@ export class ConversationEntrySheet extends JournalSheet {
     this.dropzoneVisible = false;
     this.draggingParticipant = false;
 
+    this.participants = [];
+    this.defaultActiveParticipant = undefined;
+
     const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
-    if (pages.length === 0) {
-      this.participants = [];
-    } else {
+    if (pages.length > 0) {
       try {
-        this.participants = JSON.parse(pages[0].text.content);
+        const data = JSON.parse(pages[0].text.content);
+        if (data instanceof Array) {
+          this.participants = data;
+        } else {
+          const participants = data.participants;
+          const defaultActiveParticipant = data.defaultActiveParticipant;
+          if (participants) {
+            this.participants = participants;
+            if (typeof defaultActiveParticipant !== "undefined") {
+              this.defaultActiveParticipant = defaultActiveParticipant;
+            }
+          } else {
+            throw new SyntaxError();
+          }
+        }
       } catch (error) {
         if (error instanceof SyntaxError) {
           ui.notifications.error(game.i18n.localize("CHUD.errors.failedToParse"));
         } else {
           ui.notifications.error(game.i18n.localize("CHUD.errors.genericSheetError"));
         }
-        this.participants = [];
       }
     }
   }
@@ -147,6 +161,20 @@ export class ConversationEntrySheet extends JournalSheet {
 
             // Reorder the array
             moveInArray(this.participants, oldIndex, newIndex);
+
+            // Update active participant index
+            const defaultActiveParticipantIndex = this.defaultActiveParticipant;
+            if (defaultActiveParticipantIndex === oldIndex) {
+              this.defaultActiveParticipant = newIndex;
+            } else {
+              if (defaultActiveParticipantIndex > oldIndex && defaultActiveParticipantIndex <= newIndex) {
+                this.defaultActiveParticipant -= 1;
+              }
+              if (defaultActiveParticipantIndex < oldIndex && defaultActiveParticipantIndex >= newIndex) {
+                this.defaultActiveParticipant += 1;
+              }
+            }
+
             this.dirty = true;
             this.render(false);
           } else {
@@ -156,14 +184,14 @@ export class ConversationEntrySheet extends JournalSheet {
           this.draggingParticipant = false;
         };
 
+        // Bind function to the set active by default checkbox
+        conversationParticipants[i].querySelector("#participant-active-by-default").onchange = (event) =>
+          this.#handleSetDefaultActiveParticipant(event, i);
+
         // Bind functions to the edit and remove buttons
         const controls = conversationParticipants[i].querySelector(".controls-wrapper");
-        controls.querySelector("#participant-clone-button").onclick = () => {
-          const clonedParticipant = this.participants[i];
-          this.participants.push(clonedParticipant);
-          this.dirty = true;
-          this.render(false);
-        };
+        controls.querySelector("#participant-clone-button").onclick = () => this.#handleCloneParticipant(i);
+        controls.querySelector("#participant-delete-button").onclick = () => this.#handleRemoveParticipant(i);
         controls.querySelector("#participant-edit-button").onclick = () => {
           const fileInputForm = new FileInputForm(true, (data) => this.#handleEditParticipant(data, i), {
             name: this.participants[i].name,
@@ -172,7 +200,6 @@ export class ConversationEntrySheet extends JournalSheet {
           });
           fileInputForm.render(true);
         };
-        controls.querySelector("#participant-delete-button").onclick = () => this.#handleRemoveParticipant(i);
       }
     }
   }
@@ -183,6 +210,7 @@ export class ConversationEntrySheet extends JournalSheet {
     const data = {
       isGM: game.user.isGM,
       dirty: this.dirty,
+      defaultActiveParticipant: this.defaultActiveParticipant,
       participants: this.participants,
       name: baseData.data.name,
       data: baseData.data,
@@ -225,11 +253,28 @@ export class ConversationEntrySheet extends JournalSheet {
       await this.#handleSaveConversation();
     } else {
       const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
+
       if (pages.length === 0) {
         this.participants = [];
+        this.defaultActiveParticipant = undefined;
       } else {
-        this.participants = JSON.parse(pages[0].text.content);
+        this.defaultActiveParticipant = undefined;
+
+        const data = JSON.parse(pages[0].text.content);
+        if (data instanceof Array) {
+          this.participants = data;
+        } else {
+          const participants = data.participants;
+          const defaultActiveParticipant = data.defaultActiveParticipant;
+          if (participants) {
+            this.participants = participants;
+            if (typeof defaultActiveParticipant !== "undefined") {
+              this.defaultActiveParticipant = defaultActiveParticipant;
+            }
+          }
+        }
       }
+
       this.dirty = false;
     }
     return this.close();
@@ -260,18 +305,22 @@ export class ConversationEntrySheet extends JournalSheet {
   async #handleSaveConversation() {
     // Get document pages
     const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
+    const dataToSave = {
+      defaultActiveParticipant: this.defaultActiveParticipant,
+      participants: this.participants,
+    };
 
     if (pages.length === 0) {
       // Create a document entry page if none are present
       await this.object.createEmbeddedDocuments("JournalEntryPage", [
         {
-          text: { content: JSON.stringify(this.participants) },
+          text: { content: JSON.stringify(dataToSave) },
           name: game.i18n.localize("CHUD.strings.conversationParticipants"),
         },
       ]);
     } else {
       // Otherwise, update the first (and realistically the only) entry page
-      pages[0].text.content = JSON.stringify(this.participants);
+      pages[0].text.content = JSON.stringify(dataToSave);
       await this.object.updateEmbeddedDocuments(
         "JournalEntryPage",
         [
@@ -311,6 +360,26 @@ export class ConversationEntrySheet extends JournalSheet {
 
   #handleRemoveParticipant(index) {
     this.participants.splice(index, 1);
+    this.dirty = true;
+    this.render(false);
+  }
+
+  #handleCloneParticipant(index) {
+    const clonedParticipant = this.participants[i];
+    this.participants.push(clonedParticipant);
+    this.dirty = true;
+    this.render(false);
+  }
+
+  #handleSetDefaultActiveParticipant(event, index) {
+    if (!event.target) return;
+
+    if (event.target.checked) {
+      this.defaultActiveParticipant = index;
+    } else {
+      this.defaultActiveParticipant = undefined;
+    }
+
     this.dirty = true;
     this.render(false);
   }

--- a/js/conversationEntrySheet.js
+++ b/js/conversationEntrySheet.js
@@ -196,6 +196,7 @@ export class ConversationEntrySheet extends JournalSheet {
           const fileInputForm = new FileInputForm(true, (data) => this.#handleEditParticipant(data, i), {
             name: this.participants[i].name,
             img: this.participants[i].img,
+            linkedJournal: this.participants[i].linkedJournal,
             faction: this.participants[i].faction,
           });
           fileInputForm.render(true);

--- a/js/conversationEntrySheet.js
+++ b/js/conversationEntrySheet.js
@@ -6,6 +6,7 @@ import {
   displayDragAndDropIndicator,
   getDragAndDropIndex,
   setDefaultDataForParticipant,
+  getConfirmationFromUser,
 } from "./helpers.js";
 
 export class ConversationEntrySheet extends JournalSheet {
@@ -220,33 +221,23 @@ export class ConversationEntrySheet extends JournalSheet {
     return data;
   }
 
-  close(options) {
+  async close(options) {
     if (this.dirty) {
-      const dialog = new Dialog({
-        title: game.i18n.localize("CHUD.strings.unsavedChanges"),
-        content: game.i18n.localize("CHUD.strings.unsavedChangesHint"),
-        buttons: {
-          yes: {
-            icon: '<i class="fas fa-save"></i>',
-            label: game.i18n.localize("CHUD.actions.save"),
-            callback: this.#handleConfirmationClose.bind(this, true),
-          },
-          no: {
-            icon: '<i class="fas fa-trash"></i>',
-            label: game.i18n.localize("CHUD.actions.discardChanges"),
-            callback: this.#handleConfirmationClose.bind(this, false),
-          },
-        },
-      });
-      dialog.render(true);
-      return Promise.resolve();
+      await getConfirmationFromUser(
+        "CHUD.dialogue.unsavedChanges",
+        this.#handleConfirmationClose.bind(this, true),
+        this.#handleConfirmationClose.bind(this, false),
+        '<i class="fas fa-save"></i>',
+        '<i class="fas fa-trash"></i>'
+      );
     } else {
       this.dirty = false;
       Object.values(this.editors).forEach((ed) => {
         if (ed.instance) ed.instance.destroy();
       });
-      return super.close({ submit: false });
     }
+
+    return super.close({ submit: false });
   }
 
   async #handleConfirmationClose(save) {
@@ -278,7 +269,6 @@ export class ConversationEntrySheet extends JournalSheet {
 
       this.dirty = false;
     }
-    return this.close();
   }
 
   #handleShowConversation() {

--- a/js/formAddParticipant.js
+++ b/js/formAddParticipant.js
@@ -9,6 +9,9 @@ export class FileInputForm extends FormApplication {
     this.participantName = participantData?.name || "";
     this.participantImg = participantData?.img || "";
 
+    // Linked journal
+    this.linkedJournal = participantData?.linkedJournal || "";
+
     // Faction data
     this.displayFaction = participantData?.faction?.displayFaction || false;
     this.factionName = participantData?.faction?.factionName || "";
@@ -20,7 +23,7 @@ export class FileInputForm extends FormApplication {
 
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
-      classes: ["form"],
+      classes: ["form", "scene-sheet"],
       popOut: true,
       template: `modules/conversation-hud/templates/add_edit_participant.hbs`,
       id: "conversation-add-participant",
@@ -69,6 +72,11 @@ export class FileInputForm extends FormApplication {
   }
 
   getData(options) {
+    const journals = game.journal.map((doc) => {
+      return { id: doc.id, name: doc.name };
+    });
+    journals.sort((a, b) => a.name.localeCompare(b.name));
+
     return {
       isEditing: this.isEditing,
       participantData: this.participantData,
@@ -82,6 +90,9 @@ export class FileInputForm extends FormApplication {
       factionBannerEnabled: this.factionBannerEnabled,
       factionBannerShape: this.factionBannerShape,
       factionBannerTint: this.factionBannerTint,
+
+      linkedJournal: this.linkedJournal,
+      journals: journals,
     };
   }
 
@@ -89,6 +100,7 @@ export class FileInputForm extends FormApplication {
     const participantData = {
       name: formData.participantName,
       img: formData.participantImg,
+      linkedJournal: formData.linkedJournal,
       faction: {
         displayFaction: formData.displayFaction,
         factionName: formData.factionName,

--- a/js/formConversationInput.js
+++ b/js/formConversationInput.js
@@ -168,6 +168,7 @@ export class ConversationInputForm extends FormApplication {
           const fileInputForm = new FileInputForm(true, (data) => this.#handleEditParticipant(data, i), {
             name: this.participants[i].name,
             img: this.participants[i].img,
+            linkedJournal: this.participants[i].linkedJournal,
             faction: this.participants[i].faction,
           });
           fileInputForm.render(true);

--- a/js/formConversationInput.js
+++ b/js/formConversationInput.js
@@ -13,6 +13,7 @@ export class ConversationInputForm extends FormApplication {
     super();
     this.callbackFunction = callbackFunction;
     this.participants = [];
+    this.defaultActiveParticipant = undefined;
 
     this.dropzoneVisible = false;
     this.draggingParticipant = false;
@@ -35,6 +36,7 @@ export class ConversationInputForm extends FormApplication {
     return {
       isGM: game.user.isGM,
       participants: this.participants,
+      defaultActiveParticipant: this.defaultActiveParticipant,
     };
   }
 
@@ -131,7 +133,21 @@ export class ConversationInputForm extends FormApplication {
 
             // Reorder the array
             moveInArray(this.participants, oldIndex, newIndex);
-            this.dirty = true;
+
+            // Update active participant index
+            const defaultActiveParticipantIndex = this.defaultActiveParticipant;
+            if (defaultActiveParticipantIndex === oldIndex) {
+              this.defaultActiveParticipant = newIndex;
+            } else {
+              if (defaultActiveParticipantIndex > oldIndex && defaultActiveParticipantIndex <= newIndex) {
+                this.defaultActiveParticipant -= 1;
+              }
+              if (defaultActiveParticipantIndex < oldIndex && defaultActiveParticipantIndex >= newIndex) {
+                this.defaultActiveParticipant += 1;
+              }
+            }
+
+            // Update sheet
             this.render(false);
           } else {
             console.error("ConversationHUD | Data object was empty inside conversation participant ondrop function");
@@ -140,13 +156,14 @@ export class ConversationInputForm extends FormApplication {
           this.draggingParticipant = false;
         };
 
+        // Bind function to the set active by default checkbox
+        conversationParticipants[i].querySelector("#participant-active-by-default").onchange = (event) =>
+          this.#handleSetDefaultActiveParticipant(event, i);
+
         // Bind functions to the edit and remove buttons
         const controls = conversationParticipants[i].querySelector(".controls-wrapper");
-        controls.querySelector("#participant-clone-button").onclick = () => {
-          const clonedParticipant = this.participants[i];
-          this.participants.push(clonedParticipant);
-          this.render(false);
-        };
+        controls.querySelector("#participant-clone-button").onclick = () => this.#handleCloneParticipant(i);
+        controls.querySelector("#participant-delete-button").onclick = () => this.#handleRemoveParticipant(i);
         controls.querySelector("#participant-edit-button").onclick = () => {
           const fileInputForm = new FileInputForm(true, (data) => this.#handleEditParticipant(data, i), {
             name: this.participants[i].name,
@@ -155,7 +172,6 @@ export class ConversationInputForm extends FormApplication {
           });
           fileInputForm.render(true);
         };
-        controls.querySelector("#participant-delete-button").onclick = () => this.#handleRemoveParticipant(i);
       }
     }
   }
@@ -167,6 +183,7 @@ export class ConversationInputForm extends FormApplication {
     // Data type is added as a way of future-proofing the code
     parsedData.type = 0;
     parsedData.participants = this.participants;
+    parsedData.defaultActiveParticipant = this.defaultActiveParticipant;
 
     // Pass data to conversation class
     this.callbackFunction(parsedData);
@@ -186,6 +203,24 @@ export class ConversationInputForm extends FormApplication {
 
   #handleRemoveParticipant(index) {
     this.participants.splice(index, 1);
+    this.render(false);
+  }
+
+  #handleCloneParticipant(index) {
+    const clonedParticipant = this.participants[index];
+    this.participants.push(clonedParticipant);
+    this.render(false);
+  }
+
+  #handleSetDefaultActiveParticipant(event, index) {
+    if (!event.target) return;
+
+    if (event.target.checked) {
+      this.defaultActiveParticipant = index;
+    } else {
+      this.defaultActiveParticipant = undefined;
+    }
+
     this.render(false);
   }
 }

--- a/js/handlebar-helpers.js
+++ b/js/handlebar-helpers.js
@@ -1,0 +1,19 @@
+export function registerHandlebarHelpers() {
+  registerLinkedJournalHelper();
+}
+
+function registerLinkedJournalHelper() {
+  Handlebars.registerHelper("renderParticipantLinkedJournal", (journalId) => {
+    let html = `<p class="linked-journal">`;
+
+    if (journalId) {
+      const document = game.journal.get(journalId);
+      html += `Linked journal: <a onclick="game.ConversationHud.renderJournalSheet('${journalId}')">${document.name}</a>`;
+    } else {
+      html += `No linked journal`;
+    }
+
+    html += `</p>`;
+    return html;
+  });
+}

--- a/js/handlebar-helpers.js
+++ b/js/handlebar-helpers.js
@@ -8,9 +8,14 @@ function registerLinkedJournalHelper() {
 
     if (journalId) {
       const document = game.journal.get(journalId);
-      html += `Linked journal: <a onclick="game.ConversationHud.renderJournalSheet('${journalId}')">${document.name}</a>`;
+      html += `${game.i18n.localize("CHUD.strings.linkedJournal")}: `;
+      if (document) {
+        html += `<a onclick="game.ConversationHud.renderJournalSheet('${journalId}')">${document.name}</a>`;
+      } else {
+        html += `${game.i18n.localize("CHUD.strings.invalidDocumentRef")}`;
+      }
     } else {
-      html += `No linked journal`;
+      html += `${game.i18n.localize("CHUD.strings.noLinkedJournal")}`;
     }
 
     html += `</p>`;

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -32,7 +32,16 @@ export async function getActorDataFromDragEvent(event) {
                 // Handle text pages with the the CHUD flag
                 const pageType = page.flags["conversation-hud"].type;
                 if (pageType && pageType === "conversation") {
-                  const participants = JSON.parse(page.text.content);
+                  const data = JSON.parse(page.text.content);
+                  let participants = [];
+
+                  // Determine if the data parsed respects the old data format or the new data format
+                  if (data instanceof Array) {
+                    participants = data;
+                  } else {
+                    participants = data.participants;
+                  }
+
                   conversationParticipants.push(...participants);
                 }
               } else if (page.flags["monks-enhanced-journal"]) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -323,3 +323,45 @@ export function setDefaultDataForParticipant(data) {
     }
   }
 }
+
+export function getConfirmationFromUser(
+  localizationString,
+  onConfirm,
+  onReject = () => {},
+  confirmIcon = '<i class="fas fa-check"></i>',
+  rejectIcon = '<i class="fas fa-times"></i>'
+) {
+  const dialogPromise = new Promise((resolve, reject) => {
+    const titleText = game.i18n.localize(`${localizationString}.title`);
+    const contentText = game.i18n.localize(`${localizationString}.content`);
+    const confirmText = game.i18n.localize(`${localizationString}.confirm`);
+    const rejectText = game.i18n.localize(`${localizationString}.reject`);
+
+    const dialog = new Dialog({
+      title: titleText,
+      content: `<div style="margin-bottom: 8px;">${game.i18n.localize(contentText)}</div>`,
+      buttons: {
+        confirm: {
+          icon: confirmIcon,
+          label: confirmText,
+          callback: () => {
+            onConfirm();
+            resolve(true);
+          },
+        },
+        reject: {
+          icon: rejectIcon,
+          label: rejectText,
+          callback: () => {
+            onReject();
+            resolve(false);
+          },
+        },
+      },
+      default: "confirm",
+    });
+    dialog.render(true);
+  });
+
+  return dialogPromise;
+}

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -365,3 +365,15 @@ export function getConfirmationFromUser(
 
   return dialogPromise;
 }
+
+export function checkIfCameraDockOnBottomOrTop() {
+  const cameraViews = document.getElementById("camera-views");
+
+  if (cameraViews) {
+    if (cameraViews.classList.contains("camera-position-bottom") || cameraViews.classList.contains("camera-position-top")) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/js/init.js
+++ b/js/init.js
@@ -1,5 +1,6 @@
 import { MODULE_NAME } from "./constants.js";
 import { ConversationHud } from "./conversation.js";
+import { registerHandlebarHelpers } from "./handlebar-helpers.js";
 import { checkConversationDataAvailability, fixRpgUiIncompatibility, handleOnClickContentLink } from "./helpers.js";
 import { preloadTemplates } from "./preloadTemplates.js";
 import { ModuleSettings, registerSettings } from "./settings.js";
@@ -32,6 +33,9 @@ Hooks.on("init", async () => {
 
   // Register settings
   registerSettings();
+
+  // Register handlebar helpers
+  registerHandlebarHelpers();
 
   // Load templates
   preloadTemplates();

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,7 @@
     "activateConversation": "Activate Conversation",
     "createConversation": "Create Conversation",
     "startConversation": "Start Conversation",
+    "closeConversation": "Close Conversation",
 
     "saveConversation": "Save Conversation",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,10 @@
     "portrait": "Portrait",
     "portraitHint": "Portrait of the conversation participant.",
 
+    "linkedJournal": "Linked Journal",
+    "linkedJournalHint": "Journal entry that will be linked to the conversation participant.",
+    "noLinkedJournal": "No linked journal",
+
     "conversationName": "Conversation Name",
     "conversationParticipants": "Conversation Participants",
 
@@ -26,13 +30,19 @@
 
     "dropActor": "Drop actor here to add them to the conversation",
 
-    "anonymous": "Anonymous"
+    "anonymous": "Anonymous",
+    "active": "Active",
+    "banner": "Banner",
+    "details": "Details",
+    "actions": "Actions",
+
+    "invalidDocumentRef": "Invalid document reference"
   },
 
   "CHUD.dialogue": {
     "onCloseActiveConversation": {
       "title": "Are you sure?",
-      "content": "Are you sure you want to close this conversation? Any unsaved changes or modifications will be lost.",
+      "content": "Are you sure you want to close this conversation? Any unsaved changes will be lost.",
       "confirm": "Yes",
       "reject": "No"
     },
@@ -137,7 +147,9 @@
     "insufficientRights": "Insufficient user rights.",
     "featureNotEnabled": "Feature is currently disabled. Enabled it in the settings if you wish to use it.",
 
-    "noLibWrapper": "ConversationHUD requires the libWrapper module for full functionality. Please install and activate it."
+    "noLibWrapper": "ConversationHUD requires the libWrapper module for full functionality. Please install and activate it.",
+
+    "invalidJournalEntry": "Invalid journal entry provided, please make sure that the provided journal entry is valid and has not been removed."
   },
 
   "CHUD.warnings": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,12 @@
       "confirm": "Yes",
       "reject": "No"
     },
+    "onRemoveParticipant": {
+      "title": "Are you sure?",
+      "content": "Are you sure you want to remove this participant from the currently active conversation?",
+      "confirm": "Yes",
+      "reject": "No"
+    },
     "unsavedChanges": {
       "title": "Unsaved Changes",
       "content": "The conversation contains unsaved changes. Do you wish to save them?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -29,6 +29,21 @@
     "anonymous": "Anonymous"
   },
 
+  "CHUD.dialogue": {
+    "onCloseActiveConversation": {
+      "title": "Are you sure?",
+      "content": "Are you sure you want to close this conversation? Any unsaved changes or modifications will be lost.",
+      "confirm": "Yes",
+      "reject": "No"
+    },
+    "unsavedChanges": {
+      "title": "Unsaved Changes",
+      "content": "The conversation contains unsaved changes. Do you wish to save them?",
+      "confirm": "Save Changes",
+      "reject": "Discard Changes"
+    }
+  },
+
   "CHUD.actions": {
     "save": "Save",
 

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
   },
   "authors": [
     {
-      "name": "Cristian Vasile (Saervicus)",
+      "name": "Saervicus (Cristian Vasile)",
       "discord": "Saervicus#7305",
       "url": "https://github.com/CristianVasile23"
     }

--- a/templates/conversation.hbs
+++ b/templates/conversation.hbs
@@ -19,16 +19,28 @@
           <div class="conversation-participant-wrapper">
             {{!-- Controls --}}
             <div class="controls">
-              <a class="edit" onclick="game.ConversationHud.updateParticipantFromActiveConversation({{index}})">
+              <a
+                class="edit"
+                title="{{localize 'CHUD.actions.participant.edit'}}"
+                onclick="game.ConversationHud.updateParticipantFromActiveConversation({{index}})"
+              >
                 <i class="fas fa-edit"></i>
               </a>
 
-              <a class="remove" onclick="game.ConversationHud.removeParticipantFromActiveConversation({{index}})">
+              <a
+                class="remove"
+                title="{{localize 'CHUD.actions.participant.delete'}}"
+                onclick="game.ConversationHud.removeParticipantFromActiveConversation({{index}})"
+              >
                 <i class="fas fa-trash"></i>
               </a>
 
               {{#if participant.linkedJournal}}
-                <a class="notes" onclick="game.ConversationHud.displayLinkedParticipantNotes({{index}})">
+                <a
+                  class="notes"
+                  title="{{localize 'CHUD.strings.linkedJournal'}}"
+                  onclick="game.ConversationHud.displayLinkedParticipantNotes({{index}})"
+                >
                   <i class="fas fa-book"></i>
                 </a>
               {{/if}}

--- a/templates/conversation.hbs
+++ b/templates/conversation.hbs
@@ -1,4 +1,4 @@
-<div id="conversation-hud-content" class="conversation-hud-content">
+<div id="conversation-hud-content" class="conversation-hud-content {{#if hasDock}}has-dock{{/if}}">
   {{!-- Drag and drop area --}}
   <div id="conversation-hud-dropzone" class="conversation-hud-dropzone" >
     <i class="far fa-square-plus"></i>

--- a/templates/conversation.hbs
+++ b/templates/conversation.hbs
@@ -26,6 +26,12 @@
               <a class="remove" onclick="game.ConversationHud.removeParticipantFromActiveConversation({{index}})">
                 <i class="fas fa-trash"></i>
               </a>
+
+              {{#if participant.linkedJournal}}
+                <a class="notes" onclick="game.ConversationHud.displayLinkedParticipantNotes({{index}})">
+                  <i class="fas fa-book"></i>
+                </a>
+              {{/if}}
             </div>
 
             {{!-- Participant --}}

--- a/templates/conversation_controls.hbs
+++ b/templates/conversation_controls.hbs
@@ -1,5 +1,35 @@
 {{#if isGM}}
   <div
+    class="control-button"
+    onclick="game.ConversationHud.onToggleConversation(false)"
+    data-tooltip="{{localize 'CHUD.actions.closeConversation'}}"
+  >
+    <i class="fas fa-times"></i>
+  </div>
+{{/if}}
+
+{{#if features.minimizeEnabled}}
+  {{#if (or isVisible isGM)}}
+    <div
+      class="control-button {{#if isGM}}margin-bottom{{/if}} {{#unless isVisible}}disabled{{/unless}}"
+      onclick="game.ConversationHud.toggleActiveConversationMode()"
+      {{#if isMinimized}}
+        data-tooltip="{{localize 'CHUD.actions.maximizeConversation'}}"
+      {{else}}
+        data-tooltip="{{localize 'CHUD.actions.minimizeConversation'}}"
+      {{/if}}
+    >
+      {{#if isMinimized}}
+        <i class="fas fa-chevron-left"></i>
+      {{else}}
+        <i class="fas fa-chevron-right"></i>
+      {{/if}}
+    </div>
+  {{/if}}
+{{/if}}
+
+{{#if isGM}}
+  <div
     class="control-button toggle {{#if isVisible}}active{{/if}}"
     onclick="game.ConversationHud.toggleActiveConversationVisibility()"
     data-tooltip="{{localize 'CHUD.actions.toggleVisibility'}}"
@@ -18,30 +48,10 @@
   {{/if}}
 
   <div
-    class="control-button"
+    class="control-button margin-top"
     onclick="game.ConversationHud.saveActiveConversation()"
     data-tooltip="{{localize 'CHUD.actions.saveConversation'}}"
   >
     <i class="fas fa-save"></i>
   </div>
-{{/if}}
-
-{{#if features.minimizeEnabled}}
-  {{#if isVisible}}
-    <div
-      class="control-button {{#if isGM}}margin{{/if}}"
-      onclick="game.ConversationHud.toggleActiveConversationMode()"
-      {{#if isMinimized}}
-        data-tooltip="{{localize 'CHUD.actions.maximizeConversation'}}"
-      {{else}}
-        data-tooltip="{{localize 'CHUD.actions.minimizeConversation'}}"
-      {{/if}}
-    >
-      {{#if isMinimized}}
-        <i class="fas fa-chevron-left"></i>
-      {{else}}
-        <i class="fas fa-chevron-right"></i>
-      {{/if}}
-    </div>
-  {{/if}}
 {{/if}}

--- a/templates/conversation_controls.hbs
+++ b/templates/conversation_controls.hbs
@@ -1,7 +1,7 @@
 {{#if isGM}}
   <div
     class="control-button"
-    onclick="game.ConversationHud.onToggleConversation(false)"
+    onclick="game.ConversationHud.handleCloseActiveConversation()"
     data-tooltip="{{localize 'CHUD.actions.closeConversation'}}"
   >
     <i class="fas fa-times"></i>

--- a/templates/fragments/conversation_participants_list.hbs
+++ b/templates/fragments/conversation_participants_list.hbs
@@ -2,7 +2,7 @@
   {{#if participants}}
     <div class="participants-list-header">
       <p class="active-by-default">Active</p>
-      <p class="faction">Faction</p>
+      <p class="faction">Banner</p>
       <p class="details">Details</p>
       <p class="controls">Actions</p>
     </div>
@@ -37,6 +37,8 @@
               {{else}}
                 <p class="faction">{{localize 'CHUD.faction.unaffiliated'}}</p>
               {{/if}}
+
+              {{{renderParticipantLinkedJournal participant.linkedJournal}}}
             </div>
             
             {{#if ../isGM}}

--- a/templates/fragments/conversation_participants_list.hbs
+++ b/templates/fragments/conversation_participants_list.hbs
@@ -1,7 +1,7 @@
 <div class="participants-list">
   {{#if participants}}
     <div id="conversation-participants-list">
-      {{#each participants as |participant|}}
+      {{#each participants as |participant index|}}
         <div class="participant-drag-drop-container">
           <div id="drag-drop-indicator-top" class="drag-drop-indicator"></div>
 
@@ -12,6 +12,8 @@
                 class="drag-drop-handler fa-solid fa-arrows-up-down-left-right"
                 draggable="true"
               ></i>
+
+              <input id="participant-active-by-default" type="checkbox" {{#if (eq index ../defaultActiveParticipant)}}checked="checked"{{/if}}>
             {{/if}}
 
             {{> "modules/conversation-hud/templates/fragments/faction_wrapper.hbs" faction=participant.faction}}

--- a/templates/fragments/conversation_participants_list.hbs
+++ b/templates/fragments/conversation_participants_list.hbs
@@ -1,5 +1,12 @@
 <div class="participants-list">
   {{#if participants}}
+    <div class="participants-list-header">
+      <p class="active-by-default">Active</p>
+      <p class="faction">Faction</p>
+      <p class="details">Details</p>
+      <p class="controls">Actions</p>
+    </div>
+
     <div id="conversation-participants-list">
       {{#each participants as |participant index|}}
         <div class="participant-drag-drop-container">

--- a/templates/fragments/conversation_participants_list.hbs
+++ b/templates/fragments/conversation_participants_list.hbs
@@ -1,10 +1,10 @@
 <div class="participants-list">
   {{#if participants}}
     <div class="participants-list-header">
-      <p class="active-by-default">Active</p>
-      <p class="faction">Banner</p>
-      <p class="details">Details</p>
-      <p class="controls">Actions</p>
+      <p class="active-by-default">{{localize 'CHUD.strings.active'}}</p>
+      <p class="faction">{{localize 'CHUD.strings.banner'}}</p>
+      <p class="details">{{localize 'CHUD.strings.details'}}</p>
+      <p class="controls">{{localize 'CHUD.strings.actions'}}</p>
     </div>
 
     <div id="conversation-participants-list">

--- a/templates/fragments/participant_data_config_tab.hbs
+++ b/templates/fragments/participant_data_config_tab.hbs
@@ -19,10 +19,10 @@
   </div>
 
   <div class="form-group">
-    <label>{{localize "CHUD.strings.linkedNotes"}}</label>
+    <label>{{localize "CHUD.strings.linkedJournal"}}</label>
     <select name="linkedJournal">
       {{ selectOptions journals selected=linkedJournal blank="" nameAttr="id" labelAttr="name"}}
     </select>
-    <p class="notes">{{localize "CHUD.strings.portraitHint"}}</p>
+    <p class="notes">{{localize "CHUD.strings.linkedJournalHint"}}</p>
   </div>
 </div>

--- a/templates/fragments/participant_data_config_tab.hbs
+++ b/templates/fragments/participant_data_config_tab.hbs
@@ -17,4 +17,12 @@
     </div>
     <p class="notes">{{localize "CHUD.strings.portraitHint"}}</p>
   </div>
+
+  <div class="form-group">
+    <label>{{localize "CHUD.strings.linkedNotes"}}</label>
+    <select name="linkedJournal">
+      {{ selectOptions journals selected=linkedJournal blank="" nameAttr="id" labelAttr="name"}}
+    </select>
+    <p class="notes">{{localize "CHUD.strings.portraitHint"}}</p>
+  </div>
 </div>


### PR DESCRIPTION
- Added the option to select a participant that will be enabled by default when a conversation is started
- Added the option to link journal entries to participants (MEJ entries supported)
- Added an additional button to the conversation controls that closes the currently active conversation
- Added confirmation dialogues when trying to close an active conversation or when trying to delete a participant in an active conversation
- Fixed an issue which caused UI elements to overflow when using the top or bottom position for the camera dock
- Fixed an issue which caused the conversation sheet display to close before the user could confirm if they wanted to keep or discard the unsaved changes (affected MEJ users only)
- Small UX and UI improvements