### PR TITLE
Release 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.3.0
+
+- Added a new sheet used for CHUD factions. You can now save created factions into their respective sheets, which can then be assigned to conversation participants. This means you can now create a faction, save it, and then easily assign it to multiple participants using the _Faction Selector_ dropdown found in the _Faction Config_ tab.
+- Added the option to pull scene actors into a conversation. By using the _Pull Participants from Scene_ button, you can select which actors are present in the current scene to pull into the conversation.
+- Added the option to hide the conversation participants list for the players, who will only be able to see the currently active speaker. This feature can be toggled on or off in the module settings.
+- Fixed the missing message type when using the _Speak As_ feature.
+- Small UI improvements and fixes.
+
 ## 5.2.0
 
 - Added the option to link a conversation to a scene. This option can be found in the _Scene Config_ screen on the _Ambience_ tab. Linked conversations will open automatically whenever the scene is activated.
@@ -5,18 +13,18 @@
 
 ## 5.1.0
 
-- Added the option to select a participant that will be enabled by default when a conversation is started
-- Added the option to link journal entries to participants (MEJ entries supported)
-- Added an additional button to the conversation controls that closes the currently active conversation
-- Added confirmation dialogues when trying to close an active conversation or when trying to delete a participant in an active conversation
-- Fixed an issue which caused UI elements to overflow when using the top or bottom position for the camera dock
-- Fixed an issue which caused the conversation sheet display to close before the user could confirm if they wanted to keep or discard the unsaved changes (affected MEJ users only)
-- Small UX and UI improvements
+- Added the option to select a participant that will be enabled by default when a conversation is started.
+- Added the option to link journal entries to participants (MEJ entries supported).
+- Added an additional button to the conversation controls that closes the currently active conversation.
+- Added confirmation dialogues when trying to close an active conversation or when trying to delete a participant in an active conversation.
+- Fixed an issue which caused UI elements to overflow when using the top or bottom position for the camera dock.
+- Fixed an issue which caused the conversation sheet display to close before the user could confirm if they wanted to keep or discard the unsaved changes (affected MEJ users only).
+- Small UX and UI improvements.
 
 ## 5.0.2
 
-- Fixed a bug that caused the faction of the active participant to not be hidden when conversation visibility was toggled off
-- Fixed an issue that caused the _No participant text_ to be mispositioned
+- Fixed a bug that caused the faction of the active participant to not be hidden when conversation visibility was toggled off.
+- Fixed an issue that caused the _No participant text_ to be mispositioned.
 
 ## 5.0.1
 

--- a/css/add-edit-participant-from/banner-configuration.css
+++ b/css/add-edit-participant-from/banner-configuration.css
@@ -1,18 +1,21 @@
 /* ----- Banner configuration ----- */
 /* #region */
-.participant-add-edit-form .banner-configuration {
+.participant-add-edit-form .banner-configuration,
+.conversation-faction-sheet .banner-configuration {
   display: flex;
   flex-direction: row;
 }
 
-.participant-add-edit-form .banner-options {
+.participant-add-edit-form .banner-options,
+.conversation-faction-sheet .banner-options {
   display: flex;
   flex-direction: row;
   align-items: center;
   flex: 1 !important;
 }
 
-.participant-add-edit-form .banner-options .banner-shape-button {
+.participant-add-edit-form .banner-options .banner-shape-button,
+.conversation-faction-sheet .banner-options .banner-shape-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -25,11 +28,13 @@
   margin-left: 4px;
   margin-right: 4px;
 }
-.participant-add-edit-form .banner-options .banner-shape-button.active {
+.participant-add-edit-form .banner-options .banner-shape-button.active,
+.conversation-faction-sheet .banner-options .banner-shape-button.active {
   background-color: var(--color-border-highlight);
 }
 
-.participant-add-edit-form .banner-options button img {
+.participant-add-edit-form .banner-options button img,
+.conversation-faction-sheet .banner-options button img {
   border: none;
   height: 20px;
   width: auto;
@@ -38,7 +43,8 @@
 
 /* ----- Banner preview ----- */
 /* #region */
-.participant-add-edit-form .banner-preview-wrapper {
+.participant-add-edit-form .banner-preview-wrapper,
+.conversation-faction-sheet .banner-preview-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -50,7 +56,8 @@
   padding: 5px;
 }
 
-.participant-add-edit-form .banner-preview-wrapper .banner-preview-image {
+.participant-add-edit-form .banner-preview-wrapper .banner-preview-image,
+.conversation-faction-sheet .banner-preview-wrapper .banner-preview-image {
   width: 165px;
   height: 165px;
   position: relative;
@@ -61,18 +68,22 @@
   background: rgba(0, 0, 0, 0.05);
 }
 
-.participant-add-edit-form .banner-preview-wrapper .banner-preview-image img {
+.participant-add-edit-form .banner-preview-wrapper .banner-preview-image img,
+.conversation-faction-sheet .banner-preview-wrapper .banner-preview-image img {
   border: 0;
 }
 
-.participant-add-edit-form .banner-preview-wrapper .banner-preview-image #banner-preview-flag {
+.participant-add-edit-form .banner-preview-wrapper .banner-preview-image #banner-preview-flag,
+.conversation-faction-sheet .banner-preview-wrapper .banner-preview-image #banner-preview-flag {
   display: none;
 }
-.participant-add-edit-form .banner-preview-wrapper .banner-preview-image.has-banner #banner-preview-flag {
+.participant-add-edit-form .banner-preview-wrapper .banner-preview-image.has-banner #banner-preview-flag,
+.conversation-faction-sheet .banner-preview-wrapper .banner-preview-image.has-banner #banner-preview-flag {
   display: block;
 }
 
-.participant-add-edit-form .banner-preview-wrapper .banner-preview-image #banner-preview-logo {
+.participant-add-edit-form .banner-preview-wrapper .banner-preview-image #banner-preview-logo,
+.conversation-faction-sheet .banner-preview-wrapper .banner-preview-image #banner-preview-logo {
   position: absolute;
 
   top: 0;
@@ -85,18 +96,21 @@
 
   margin: auto;
 }
-.banner-preview-wrapper .banner-preview-image.has-banner #banner-preview-logo {
+.banner-preview-wrapper .banner-preview-image.has-banner #banner-preview-logo,
+.conversation-faction-sheet .banner-preview-image.has-banner #banner-preview-logo {
   top: 30px;
   bottom: unset;
 
   max-width: 70px;
   max-height: 70px;
 }
-.banner-preview-wrapper .banner-preview-image #banner-preview-logo[src=""] {
+.banner-preview-wrapper .banner-preview-image #banner-preview-logo[src=""],
+.conversation-faction-sheet .banner-preview-image #banner-preview-logo[src=""] {
   display: none;
 }
 
-.participant-add-edit-form .banner-preview-wrapper .no-banner-preview-text {
+.participant-add-edit-form .banner-preview-wrapper .no-banner-preview-text,
+.conversation-faction-sheet .banner-preview-wrapper .no-banner-preview-text {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/css/add-edit-participant-from/banner-configuration.css
+++ b/css/add-edit-participant-from/banner-configuration.css
@@ -131,9 +131,17 @@
 
 /* ----- View only ----- */
 /* #region */
-.participant-add-edit-form .view-only .banner-shape-button:disabled,
-.conversation-faction-sheet .view-only .banner-shape-button:disabled {
+.participant-add-edit-form .view-only .banner-shape-button,
+.conversation-faction-sheet .view-only .banner-shape-button {
   opacity: 0.65;
   cursor: initial;
+  pointer-events: none;
+}
+
+.participant-add-edit-form .view-only input,
+.conversation-faction-sheet .view-only input {
+  pointer-events: none;
+  border: none;
+  color: var(--color-text-dark-secondary);
 }
 /* #endregion */

--- a/css/add-edit-participant-from/banner-configuration.css
+++ b/css/add-edit-participant-from/banner-configuration.css
@@ -145,3 +145,19 @@
   color: var(--color-text-dark-secondary);
 }
 /* #endregion */
+
+/* ----- Faction export button ----- */
+/* #region */
+.participant-add-edit-form #exportFaction {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0;
+  width: 36px;
+  height: 28px;
+}
+
+.conversation-faction-sheet #exportFaction {
+  display: none;
+}
+/* #endregion */

--- a/css/add-edit-participant-from/banner-configuration.css
+++ b/css/add-edit-participant-from/banner-configuration.css
@@ -128,3 +128,12 @@
   color: var(--color-text-dark-primary);
 }
 /* #endregion */
+
+/* ----- View only ----- */
+/* #region */
+.participant-add-edit-form .view-only .banner-shape-button:disabled,
+.conversation-faction-sheet .view-only .banner-shape-button:disabled {
+  opacity: 0.65;
+  cursor: initial;
+}
+/* #endregion */

--- a/css/conversation-entry-sheet/drag-and-drop.css
+++ b/css/conversation-entry-sheet/drag-and-drop.css
@@ -7,11 +7,19 @@
   margin-top: 5px;
   margin-bottom: 5px;
 }
+
+.conversation-faction-sheet .drag-and-drop-wrapper {
+  position: relative;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
 /* #endregion */
 
 /* ----- Dropzone ----- */
 /* #region */
-.conversation-entry-sheet .drag-and-drop-wrapper .dropzone {
+.conversation-entry-sheet .drag-and-drop-wrapper .dropzone,
+.conversation-faction-sheet .drag-and-drop-wrapper .dropzone {
   display: none;
   flex-flow: column;
   align-items: center;
@@ -28,11 +36,13 @@
   border: 5px dashed var(--color-border-light-secondary);
 }
 
-.conversation-entry-sheet .drag-and-drop-wrapper .dropzone > i {
+.conversation-entry-sheet .drag-and-drop-wrapper .dropzone > i,
+.conversation-faction-sheet .drag-and-drop-wrapper .dropzone > i {
   font-size: 60px;
 }
 
-.conversation-entry-sheet .drag-and-drop-wrapper .dropzone > p {
+.conversation-entry-sheet .drag-and-drop-wrapper .dropzone > p,
+.conversation-faction-sheet .drag-and-drop-wrapper .dropzone > p {
   color: var(--color-text-dark-secondary);
 
   margin-top: 15px;
@@ -40,17 +50,20 @@
   text-align: center;
 }
 
-.conversation-entry-sheet .drag-and-drop-wrapper .dropzone * {
+.conversation-entry-sheet .drag-and-drop-wrapper .dropzone *,
+.conversation-faction-sheet .drag-and-drop-wrapper .dropzone * {
   pointer-events: none;
 }
 /* #endregion */
 
 /* ----- Active dropzone rule overrides ----- */
 /* #region */
-.conversation-entry-sheet .drag-and-drop-wrapper.active-dropzone .dropzone {
+.conversation-entry-sheet .drag-and-drop-wrapper.active-dropzone .dropzone,
+.conversation-faction-sheet .drag-and-drop-wrapper.active-dropzone .dropzone {
   display: flex;
 }
-.conversation-entry-sheet .drag-and-drop-wrapper.active-dropzone .participants-list {
+.conversation-entry-sheet .drag-and-drop-wrapper.active-dropzone .participants-list,
+.conversation-faction-sheet .drag-and-drop-wrapper.active-dropzone .participants-list {
   display: none;
 }
 /* #endregion */

--- a/css/conversation-entry-sheet/sheet.css
+++ b/css/conversation-entry-sheet/sheet.css
@@ -1,6 +1,7 @@
 /* ----- Header ----- */
 /* #region */
-.conversation-entry-sheet .header {
+.conversation-entry-sheet .header,
+.conversation-faction-sheet .header {
   display: flex;
   flex-flow: row;
   align-items: center;
@@ -10,7 +11,8 @@
   flex: 0;
 }
 
-.conversation-entry-sheet .header > input {
+.conversation-entry-sheet .header > input,
+.conversation-faction-sheet .header > input {
   background: none !important;
   border: 1px solid transparent !important;
 
@@ -18,11 +20,14 @@
   font-size: 1.5em !important;
 }
 .conversation-entry-sheet .header > input:hover,
-.conversation-entry-sheet .header > input:focus {
+.conversation-entry-sheet .header > input:focus,
+.conversation-faction-sheet .header > input:hover,
+.conversation-faction-sheet .header > input:focus {
   box-shadow: none !important;
 }
 
-.conversation-entry-sheet .header > p {
+.conversation-entry-sheet .header > p,
+.conversation-faction-sheet .header > p {
   display: flex;
   align-items: center;
   flex: 3;

--- a/css/conversation-entry-sheet/sheet.css
+++ b/css/conversation-entry-sheet/sheet.css
@@ -44,7 +44,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 0;
+  flex: 0 0 32px;
   width: 32px;
   height: 32px;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -10,5 +10,8 @@
 /* CSS for the active conversation */
 @import url("./active-conversation/index.css");
 
+/* CSS fopr the pull participants feature */
+@import url("./pull-participants/index.css");
+
 /* Misc CSS used for various aspects of the module */
 @import url("./misc.css");

--- a/css/pull-participants/index.css
+++ b/css/pull-participants/index.css
@@ -1,0 +1,138 @@
+/* ----- Header ----- */
+/* #region */
+.pull-participants-from-scene-form .header {
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  margin-top: 5px;
+  border-bottom: 1px solid var(--color-underline-header);
+  height: 34px;
+  flex: 0;
+}
+
+.pull-participants-from-scene-form .header > p {
+  display: flex;
+  align-items: center;
+  flex: 3;
+  margin: 0;
+
+  color: var(--color-text-dark-primary);
+  font-size: 1.5em;
+}
+/* #endregion */
+
+/* ----- Header buttons ----- */
+/* #region */
+.pull-participants-from-scene-form .header .header-action-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 32px;
+  width: 32px;
+  height: 32px;
+}
+
+.pull-participants-from-scene-form .header .header-action-button i {
+  margin: 0;
+}
+/* #endregion */
+
+/* ----- Pulled actors list ----- */
+/* #region */
+.pull-participants-from-scene-form .list-wrapper {
+  height: 100%;
+  overflow-y: auto;
+  position: relative;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.pull-participants-from-scene-form #participants-pulled-from-scene {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+.pull-participants-from-scene-form .pulled-participant {
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  padding: 5px;
+
+  border-bottom: 1px solid var(--color-border-light-2);
+}
+
+.pull-participants-from-scene-form .pulled-participant:last-child {
+  border-bottom: none;
+}
+/* #endregion */
+
+/* ----- Portrait Display ----- */
+/* #region */
+.pull-participants-from-scene-form .portrait-wrapper {
+  height: 44px;
+  width: 44px;
+  margin-left: 15px;
+
+  border: 1px solid var(--color-border-dark);
+  border-radius: 3px;
+}
+
+.pull-participants-from-scene-form .portrait-wrapper img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+  object-position: top center;
+  border: 0;
+  border-radius: 0;
+}
+/* #endregion */
+
+/* ----- Text Display ----- */
+/* #region */
+.pull-participants-from-scene-form .text-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  margin-left: 10px;
+}
+
+.pull-participants-from-scene-form .text-wrapper .name {
+  margin: 0;
+  font-weight: bold;
+  color: var(--color-text-dark-secondary);
+}
+
+.pull-participants-from-scene-form .text-wrapper .is-hidden {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.pull-participants-from-scene-form .text-wrapper .is-hidden i {
+  margin-right: 3px;
+  font-size: 10px;
+}
+
+.pull-participants-from-scene-form .text-wrapper .is-hidden p {
+  margin: 0;
+  font-style: italic;
+  font-size: 11px;
+}
+/* #endregion */
+
+/* ----- Checkbox ----- */
+/* #region */
+.pull-participants-from-scene-form .pull-participant-checkbox {
+  margin-left: auto;
+  margin-right: 15px;
+}
+/* #endregion */
+
+/* ----- Footer ----- */
+/* #region */
+.pull-participants-from-scene-form .footer {
+  flex: unset;
+}
+/* #endregion */

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,1 +1,9 @@
 export const MODULE_NAME = "conversation-hud";
+
+export const EMPTY_FACTION = {
+  factionName: "",
+  factionLogo: "",
+  factionBannerEnabled: false,
+  factionBannerShape: "shape-1",
+  factionBannerTint: "#000000",
+};

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -1,6 +1,7 @@
 import { ConversationInputForm } from "./formConversationInput.js";
 import { FileInputForm } from "./formAddParticipant.js";
 import { ConversationEntrySheet } from "./conversationEntrySheet.js";
+import { ConversationFactionSheet } from "./sheets/FactionSheet.js";
 import {
   checkIfConversationActive,
   checkIfUserGM,
@@ -68,6 +69,12 @@ export class ConversationHud {
       types: ["base"],
       makeDefault: false,
       label: game.i18n.localize("CHUD.sheets.entrySheet"),
+    });
+
+    DocumentSheetConfig.registerSheet(JournalEntry, "conversation-faction-sheet", ConversationFactionSheet, {
+      types: ["base"],
+      makeDefault: false,
+      label: game.i18n.localize("CHUD.sheets.factionSheet"),
     });
   }
 
@@ -507,6 +514,8 @@ export class ConversationHud {
 
       conversationData.activeParticipant = -1;
       conversationData.defaultActiveParticipant = undefined;
+
+      console.log(data);
 
       if (data instanceof Array) {
         conversationData.participants = data;

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -1,5 +1,6 @@
 import { ConversationInputForm } from "./formConversationInput.js";
 import { FileInputForm } from "./formAddParticipant.js";
+import { PullParticipantsForm } from "./formPullParticipants.js";
 import { ConversationEntrySheet } from "./sheets/ConversationEntrySheet.js";
 import { ConversationFactionSheet } from "./sheets/ConversationFactionSheet.js";
 import {
@@ -16,6 +17,7 @@ import {
   getConfirmationFromUser,
   checkIfCameraDockOnBottomOrTop,
   getConversationDataFromJournalId,
+  convertActorToParticipant,
 } from "./helpers.js";
 import { socket } from "./init.js";
 import { MODULE_NAME } from "./constants.js";
@@ -404,6 +406,26 @@ export class ConversationHud {
     }
   }
 
+  // Function that adds an actor to the active conversation
+  addActorToActiveConversation(actorId) {
+    if (checkIfUserGM()) {
+      const actor = game.actors.get(actorId);
+      const participant = convertActorToParticipant(actor);
+      this.#handleAddParticipant(participant);
+    }
+  }
+
+  // Function that adds multiple actors to active conversation
+  addActorsToActiveConversation(arrayOfActorIds) {
+    if (checkIfUserGM()) {
+      for (const actorId of arrayOfActorIds) {
+        const actor = game.actors.get(actorId);
+        const participant = convertActorToParticipant(actor);
+        this.#handleAddParticipant(participant);
+      }
+    }
+  }
+
   // Function that handles drag and drop order rearrangement of conversation participants
   async handleParticipantDrop(event) {
     if (checkIfUserGM()) {
@@ -664,6 +686,18 @@ export class ConversationHud {
       }
 
       journal.sheet.render(true);
+    }
+  }
+
+  // Function that pulls actors from the current scene
+  pullActorsFromScene() {
+    if (checkIfUserGM()) {
+      const pullParticipantsForm = new PullParticipantsForm((data) => {
+        for (const participant of data) {
+          this.#handleAddParticipant(participant);
+        }
+      });
+      return pullParticipantsForm.render(true);
     }
   }
 

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -92,8 +92,10 @@ export class ConversationHud {
       isGM: game.user.isGM,
       portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),
       portraitAnchor: game.settings.get(MODULE_NAME, ModuleSettings.portraitAnchor),
+      displayParticipantsToPlayers: game.settings.get(MODULE_NAME, ModuleSettings.displayAllParticipantsToPlayers),
       activeParticipantFontSize: game.settings.get(MODULE_NAME, ModuleSettings.activeParticipantFontSize),
     });
+
     const conversationControls = await renderTemplate("modules/conversation-hud/templates/conversation_controls.hbs", {
       isGM: game.user.isGM,
       isMinimized: game.ConversationHud.conversationIsMinimized,
@@ -304,6 +306,7 @@ export class ConversationHud {
       isGM: game.user.isGM,
       portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),
       portraitAnchor: game.settings.get(MODULE_NAME, ModuleSettings.portraitAnchor),
+      displayParticipantsToPlayers: game.settings.get(MODULE_NAME, ModuleSettings.displayAllParticipantsToPlayers),
       activeParticipantFontSize: game.settings.get(MODULE_NAME, ModuleSettings.activeParticipantFontSize),
     });
 
@@ -362,14 +365,20 @@ export class ConversationHud {
 
   // Function that changes the active participant image
   async changeActiveImage(index) {
-    const activeParticipantTemplate = await renderTemplate("modules/conversation-hud/templates/fragments/active_participant.hbs", {
-      displayParticipant: index === -1 ? false : true,
-      participant: game.ConversationHud.activeConversation.participants[index],
-      portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),
-      portraitAnchor: game.settings.get(MODULE_NAME, ModuleSettings.portraitAnchor),
-      activeParticipantFontSize: game.settings.get(MODULE_NAME, ModuleSettings.activeParticipantFontSize),
-      activeParticipantFactionFontSize: game.settings.get(MODULE_NAME, ModuleSettings.activeParticipantFactionFontSize),
-    });
+    const activeParticipantTemplate = await renderTemplate(
+      "modules/conversation-hud/templates/fragments/active_participant.hbs",
+      {
+        displayParticipant: index === -1 ? false : true,
+        participant: game.ConversationHud.activeConversation.participants[index],
+        portraitStyle: game.settings.get(MODULE_NAME, ModuleSettings.portraitStyle),
+        portraitAnchor: game.settings.get(MODULE_NAME, ModuleSettings.portraitAnchor),
+        activeParticipantFontSize: game.settings.get(MODULE_NAME, ModuleSettings.activeParticipantFontSize),
+        activeParticipantFactionFontSize: game.settings.get(
+          MODULE_NAME,
+          ModuleSettings.activeParticipantFactionFontSize
+        ),
+      }
+    );
 
     const activeParticipantAnchorPoint = document.querySelector("#active-participant-anchor-point");
     activeParticipantAnchorPoint.innerHTML = activeParticipantTemplate;
@@ -496,7 +505,9 @@ export class ConversationHud {
   }
 
   updateActivateHudButton(status) {
-    ui.controls.controls.find((controls) => controls.name === "notes").tools.find((tools) => tools.name === "activateHud").active = status;
+    ui.controls.controls
+      .find((controls) => controls.name === "notes")
+      .tools.find((tools) => tools.name === "activateHud").active = status;
     ui.controls.render();
   }
 

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -18,6 +18,7 @@ import {
   checkIfCameraDockOnBottomOrTop,
   getConversationDataFromJournalId,
   convertActorToParticipant,
+  updateParticipantFactionBasedOnSelectedFaction,
 } from "./helpers.js";
 import { socket } from "./init.js";
 import { MODULE_NAME } from "./constants.js";
@@ -86,6 +87,13 @@ export class ConversationHud {
     game.ConversationHud.conversationIsActive = true;
     game.ConversationHud.conversationIsVisible = conversationVisible;
     game.ConversationHud.activeConversation = conversationData;
+
+    // Update faction banners
+    for (const participant of conversationData.participants) {
+      if (participant.faction.selectedFaction) {
+        updateParticipantFactionBasedOnSelectedFaction(participant);
+      }
+    }
 
     // Render templates
     const renderedHtml = await renderTemplate("modules/conversation-hud/templates/conversation.hbs", {
@@ -300,6 +308,13 @@ export class ConversationHud {
   async updateActiveConversation(conversationData) {
     // Set conversation data
     game.ConversationHud.activeConversation = conversationData;
+
+    // Update faction banners
+    for (const participant of conversationData.participants) {
+      if (participant.faction.selectedFaction) {
+        updateParticipantFactionBasedOnSelectedFaction(participant);
+      }
+    }
 
     // Render template
     const renderedHtml = await renderTemplate("modules/conversation-hud/templates/conversation.hbs", {
@@ -739,6 +754,10 @@ export class ConversationHud {
   // Function that adds a single participant to the active conversation
   #handleAddParticipant(data) {
     setDefaultDataForParticipant(data);
+
+    if (data.faction.selectedFaction) {
+      updateParticipantFactionBasedOnSelectedFaction(data);
+    }
 
     // Push participant to the active conversation then update all the others
     game.ConversationHud.activeConversation.participants.push(data);

--- a/js/conversation.js
+++ b/js/conversation.js
@@ -1,7 +1,7 @@
 import { ConversationInputForm } from "./formConversationInput.js";
 import { FileInputForm } from "./formAddParticipant.js";
-import { ConversationEntrySheet } from "./conversationEntrySheet.js";
-import { ConversationFactionSheet } from "./sheets/FactionSheet.js";
+import { ConversationEntrySheet } from "./sheets/ConversationEntrySheet.js";
+import { ConversationFactionSheet } from "./sheets/ConversationFactionSheet.js";
 import {
   checkIfConversationActive,
   checkIfUserGM,
@@ -514,8 +514,6 @@ export class ConversationHud {
 
       conversationData.activeParticipant = -1;
       conversationData.defaultActiveParticipant = undefined;
-
-      console.log(data);
 
       if (data instanceof Array) {
         conversationData.participants = data;

--- a/js/conversationEntrySheet.js
+++ b/js/conversationEntrySheet.js
@@ -356,7 +356,7 @@ export class ConversationEntrySheet extends JournalSheet {
   }
 
   #handleCloneParticipant(index) {
-    const clonedParticipant = this.participants[i];
+    const clonedParticipant = this.participants[index];
     this.participants.push(clonedParticipant);
     this.dirty = true;
     this.render(false);

--- a/js/formAddParticipant.js
+++ b/js/formAddParticipant.js
@@ -79,7 +79,6 @@ export class FileInputForm extends FormApplication {
 
     // Faction save button
     const exportFaction = html.find("[name=exportFaction]")[0];
-    console.log(exportFaction);
     if (exportFaction) {
       exportFaction.addEventListener("click", () => this.saveFaction());
     }
@@ -234,7 +233,6 @@ export class FileInputForm extends FormApplication {
       content: dialogContent,
       label: "Save Faction",
       callback: (html) => {
-        console.log();
         const formElement = html[0].querySelector("form");
         const formData = new FormDataExtended(formElement);
         const formDataObject = formData.object;

--- a/js/formConversationInput.js
+++ b/js/formConversationInput.js
@@ -1,4 +1,5 @@
 import { FileInputForm } from "./formAddParticipant.js";
+import { PullParticipantsForm } from "./formPullParticipants.js";
 import {
   getActorDataFromDragEvent,
   moveInArray,
@@ -41,6 +42,16 @@ export class ConversationInputForm extends FormApplication {
   }
 
   activateListeners(html) {
+    // Add event listener on the pull participants from scene button
+    html.find("#pull-participants-from-scene").click(async (e) => {
+      const pullParticipantsForm = new PullParticipantsForm((data) => {
+        for (const participant of data) {
+          this.#handleAddParticipant(participant);
+        }
+      });
+      return pullParticipantsForm.render(true);
+    });
+
     // Add event listener on the add participant button
     html.find("#add-participant").click(async (e) => {
       const fileInputForm = new FileInputForm(false, (data) => this.#handleAddParticipant(data));

--- a/js/formConversationInput.js
+++ b/js/formConversationInput.js
@@ -7,6 +7,7 @@ import {
   displayDragAndDropIndicator,
   getDragAndDropIndex,
   setDefaultDataForParticipant,
+  updateParticipantFactionBasedOnSelectedFaction,
 } from "./helpers.js";
 
 export class ConversationInputForm extends FormApplication {
@@ -34,6 +35,12 @@ export class ConversationInputForm extends FormApplication {
   }
 
   getData() {
+    for (const participant of this.participants) {
+      if (participant.faction.selectedFaction) {
+        updateParticipantFactionBasedOnSelectedFaction(participant);
+      }
+    }
+
     return {
       isGM: game.user.isGM,
       participants: this.participants,
@@ -209,6 +216,11 @@ export class ConversationInputForm extends FormApplication {
 
   #handleAddParticipant(data) {
     setDefaultDataForParticipant(data);
+
+    if (data.faction.selectedFaction) {
+      updateParticipantFactionBasedOnSelectedFaction(data);
+    }
+
     this.participants.push(data);
     this.render(false);
   }

--- a/js/formPullParticipants.js
+++ b/js/formPullParticipants.js
@@ -1,0 +1,96 @@
+export class PullParticipantsForm extends FormApplication {
+  constructor(callbackFunction) {
+    super();
+    this.callbackFunction = callbackFunction;
+
+    // Get all NPCs from current scene
+    const tokens = game.scenes.current.tokens;
+    const participants = tokens.map((token) => {
+      const actor = token.actor;
+      const participant = {
+        name: token.name,
+        img: actor.img,
+        id: token.id,
+        checked: token.hidden ? false : true,
+        hidden: token.hidden,
+      };
+      return participant;
+    });
+
+    this.participants = participants;
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ["form"],
+      popOut: true,
+      template: `modules/conversation-hud/templates/pull_participants.hbs`,
+      id: "conversation-pull-participants",
+      title: game.i18n.localize("CHUD.actions.pullParticipants"),
+      width: 435,
+      height: 650,
+      resizable: false,
+    });
+  }
+
+  getData() {
+    return {
+      participants: this.participants,
+    };
+  }
+
+  async _updateObject(event, formData) {
+    const selectedParticipants = [];
+    for (const participant of this.participants) {
+      if (participant.checked) {
+        selectedParticipants.push(participant);
+      }
+    }
+    this.callbackFunction(selectedParticipants);
+  }
+
+  activateListeners(html) {
+    html.find("#deselect-all").click(() => {
+      this.#setCheckedStatusForAllActors(false);
+    });
+
+    html.find("#select-visible").click(() => {
+      this.#handleSelectOnlyVisibleActors();
+    });
+
+    html.find("#select-all").click(() => {
+      this.#setCheckedStatusForAllActors(true);
+    });
+
+    const actorsObject = html.find("#participants-pulled-from-scene")[0];
+    if (actorsObject) {
+      const pulledActors = actorsObject.children;
+      for (let i = 0; i < pulledActors.length; i++) {
+        pulledActors[i].querySelector("#pull-participant-checkbox").onchange = (event) =>
+          this.#handleSetIncludeActorCheckbox(event, i);
+      }
+    }
+  }
+
+  #setCheckedStatusForAllActors(value) {
+    for (let i = 0; i < this.participants.length; i++) {
+      this.participants[i].checked = value;
+    }
+    this.render(false);
+  }
+
+  #handleSelectOnlyVisibleActors() {
+    for (let i = 0; i < this.participants.length; i++) {
+      if (this.participants[i].hidden) {
+        this.participants[i].checked = false;
+      } else {
+        this.participants[i].checked = true;
+      }
+    }
+    this.render(false);
+  }
+
+  #handleSetIncludeActorCheckbox(event, index) {
+    this.participants[index].checked = event.target.checked;
+  }
+}

--- a/js/formPullParticipants.js
+++ b/js/formPullParticipants.js
@@ -1,3 +1,5 @@
+import { EMPTY_FACTION } from "./constants.js";
+
 export class PullParticipantsForm extends FormApplication {
   constructor(callbackFunction) {
     super();
@@ -43,7 +45,13 @@ export class PullParticipantsForm extends FormApplication {
     const selectedParticipants = [];
     for (const participant of this.participants) {
       if (participant.checked) {
-        selectedParticipants.push(participant);
+        const parsedParticipant = {
+          faction: EMPTY_FACTION,
+          img: participant.img,
+          linkedJournal: "",
+          name: participant.name,
+        };
+        selectedParticipants.push(parsedParticipant);
       }
     }
     this.callbackFunction(selectedParticipants);

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -412,3 +412,15 @@ export function convertActorToParticipant(actor) {
 
   return participant;
 }
+
+export function updateParticipantFactionBasedOnSelectedFaction(participant) {
+  if (participant.faction.selectedFaction) {
+    const factionData = getConversationDataFromJournalId(participant.faction.selectedFaction);
+    const selectedFactionData = factionData.faction;
+    participant.faction = {
+      ...selectedFactionData,
+      displayFaction: participant.faction.displayFaction,
+      selectedFaction: participant.faction.selectedFaction,
+    };
+  }
+}

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,5 +1,5 @@
 import { socket } from "./init.js";
-import { MODULE_NAME } from "./constants.js";
+import { EMPTY_FACTION, MODULE_NAME } from "./constants.js";
 import { ModuleSettings } from "./settings.js";
 
 export async function getActorDataFromDragEvent(event) {
@@ -370,7 +370,10 @@ export function checkIfCameraDockOnBottomOrTop() {
   const cameraViews = document.getElementById("camera-views");
 
   if (cameraViews) {
-    if (cameraViews.classList.contains("camera-position-bottom") || cameraViews.classList.contains("camera-position-top")) {
+    if (
+      cameraViews.classList.contains("camera-position-bottom") ||
+      cameraViews.classList.contains("camera-position-top")
+    ) {
       return true;
     }
   }
@@ -397,4 +400,15 @@ export function getConversationDataFromJournalId(journalId) {
   }
 
   return null;
+}
+
+export function convertActorToParticipant(actor) {
+  const participant = {
+    faction: EMPTY_FACTION,
+    img: actor.img,
+    linkedJournal: "",
+    name: actor.name,
+  };
+
+  return participant;
 }

--- a/js/hooks.js
+++ b/js/hooks.js
@@ -29,6 +29,7 @@ Hooks.on("chatMessage", (chatLog, message, chatData) => {
   let newChatData = {
     content: message,
     ...chatData,
+    type: CONST.CHAT_MESSAGE_TYPES.IC,
   };
   newChatData.speaker.alias = participant.name;
   newChatData.speaker.actor = null;
@@ -41,13 +42,18 @@ Hooks.on("chatMessage", (chatLog, message, chatData) => {
 // Hook that injects scene conversation HTML into the scene config screen
 Hooks.on("renderSceneConfig", async (app, html, data) => {
   if (game.settings.get(MODULE_NAME, ModuleSettings.enableSceneConversations)) {
-    const conversations = game.journal.filter((item) => item.flags.core?.sheetClass === "conversation-entry-sheet.ConversationEntrySheet");
+    const conversations = game.journal.filter(
+      (item) => item.flags.core?.sheetClass === "conversation-entry-sheet.ConversationEntrySheet"
+    );
     const linkedConversation = data.data["flags"]["conversation-hud"]?.sceneConversation || undefined;
 
-    const renderedHtml = await renderTemplate("modules/conversation-hud/templates/fragments/scene_conversation_selector.hbs", {
-      conversations: conversations,
-      linkedConversation: linkedConversation,
-    });
+    const renderedHtml = await renderTemplate(
+      "modules/conversation-hud/templates/fragments/scene_conversation_selector.hbs",
+      {
+        conversations: conversations,
+        linkedConversation: linkedConversation,
+      }
+    );
 
     html.find('div[data-tab="ambience"] > .form-group').last().after(renderedHtml);
     app.setPosition({ height: "auto" });

--- a/js/hooks.js
+++ b/js/hooks.js
@@ -24,6 +24,14 @@ Hooks.on("chatMessage", (chatLog, message, chatData) => {
   // Get active participant
   const participant = game.ConversationHud.activeConversation.participants[activeParticipant];
 
+  // Additional check if using tabbed-chatlog to see if the OOC tab is selected, in which case
+  // we render the original unchanged message
+  if (game.modules.get("tabbed-chatlog")?.active) {
+    if ($(".tabbedchatlog a.active").hasClass("ooc")) {
+      return true;
+    }
+  }
+
   // Remove leading commands if there are any
   message = message.replace(/\\n/g, "<br>");
   let newChatData = {

--- a/js/settings.js
+++ b/js/settings.js
@@ -3,6 +3,7 @@ import { MODULE_NAME } from "./constants.js";
 export const ModuleSettings = {
   portraitStyle: "portraitStyle",
   portraitAnchor: "portraitAnchor",
+  displayAllParticipantsToPlayers: "displayAllParticipantsToPlayers",
   enableMinimize: "enableMinimize",
   enableSpeakAs: "enableSpeakAs",
   enableSceneConversations: "enableSceneConversations",
@@ -40,6 +41,16 @@ export function registerSettings() {
       center: game.i18n.localize(`CHUD.settings.portraitAnchor.choices.center`),
       bottom: game.i18n.localize(`CHUD.settings.portraitAnchor.choices.bottom`),
     },
+  });
+
+  game.settings.register(MODULE_NAME, ModuleSettings.displayAllParticipantsToPlayers, {
+    name: game.i18n.localize(`CHUD.settings.displayAllParticipantsToPlayers.name`),
+    hint: game.i18n.localize(`CHUD.settings.displayAllParticipantsToPlayers.hint`),
+    scope: "world",
+    config: true,
+    requiresReload: true,
+    type: Boolean,
+    default: true,
   });
 
   game.settings.register(MODULE_NAME, ModuleSettings.enableSpeakAs, {

--- a/js/sheets/ConversationEntrySheet.js
+++ b/js/sheets/ConversationEntrySheet.js
@@ -8,6 +8,7 @@ import {
   getDragAndDropIndex,
   setDefaultDataForParticipant,
   getConfirmationFromUser,
+  updateParticipantFactionBasedOnSelectedFaction,
 } from "../helpers.js";
 
 export class ConversationEntrySheet extends JournalSheet {
@@ -219,6 +220,12 @@ export class ConversationEntrySheet extends JournalSheet {
   getData(options) {
     const baseData = super.getData(options);
 
+    for (const participant of this.participants) {
+      if (participant.faction.selectedFaction) {
+        updateParticipantFactionBasedOnSelectedFaction(participant);
+      }
+    }
+
     const data = {
       isGM: game.user.isGM,
       dirty: this.dirty,
@@ -353,6 +360,10 @@ export class ConversationEntrySheet extends JournalSheet {
 
   #handleAddParticipant(data) {
     setDefaultDataForParticipant(data);
+
+    if (data.faction.selectedFaction) {
+      updateParticipantFactionBasedOnSelectedFaction(data);
+    }
 
     this.participants.push(data);
     this.dirty = true;

--- a/js/sheets/ConversationEntrySheet.js
+++ b/js/sheets/ConversationEntrySheet.js
@@ -1,4 +1,5 @@
 import { FileInputForm } from "../formAddParticipant.js";
+import { PullParticipantsForm } from "../formPullParticipants.js";
 import {
   getActorDataFromDragEvent,
   moveInArray,
@@ -71,6 +72,15 @@ export class ConversationEntrySheet extends JournalSheet {
     html.find("#save-conversation").click(async (e) => this.#handleSaveConversation());
 
     html.find("#show-conversation").click(async (e) => this.#handleShowConversation());
+
+    html.find("#pull-participants-from-scene").click(async (e) => {
+      const pullParticipantsForm = new PullParticipantsForm((data) => {
+        for (const participant of data) {
+          this.#handleAddParticipant(participant);
+        }
+      });
+      return pullParticipantsForm.render(true);
+    });
 
     html.find("#add-participant").click(async (e) => {
       const fileInputForm = new FileInputForm(false, (data) => this.#handleAddParticipant(data));

--- a/js/sheets/ConversationEntrySheet.js
+++ b/js/sheets/ConversationEntrySheet.js
@@ -1,4 +1,4 @@
-import { FileInputForm } from "./formAddParticipant.js";
+import { FileInputForm } from "../formAddParticipant.js";
 import {
   getActorDataFromDragEvent,
   moveInArray,
@@ -7,7 +7,7 @@ import {
   getDragAndDropIndex,
   setDefaultDataForParticipant,
   getConfirmationFromUser,
-} from "./helpers.js";
+} from "../helpers.js";
 
 export class ConversationEntrySheet extends JournalSheet {
   constructor(data, options) {

--- a/js/sheets/ConversationFactionSheet.js
+++ b/js/sheets/ConversationFactionSheet.js
@@ -54,9 +54,6 @@ export class ConversationFactionSheet extends JournalSheet {
       return;
     }
 
-    const displayFactionToggle = html.find("[name=displayFaction]")[0];
-    displayFactionToggle.addEventListener("change", (event) => this.onToggleFactionDisplay(event));
-
     const factionNameInput = html.find("[name=factionName]")[0];
     factionNameInput.addEventListener("change", (event) => this.onUpdateFactionName(event));
 

--- a/js/sheets/FactionSheet.js
+++ b/js/sheets/FactionSheet.js
@@ -1,0 +1,224 @@
+import { getConfirmationFromUser } from "../helpers.js";
+
+const EMPTY_FACTION = {
+  displayFaction: false,
+  factionName: "",
+  factionLogo: "",
+  factionBannerEnabled: false,
+  factionBannerShape: "shape-1",
+  factionBannerTint: "#000000",
+};
+
+export class ConversationFactionSheet extends JournalSheet {
+  constructor(data, options) {
+    super(data, options);
+
+    this.dirty = false;
+    this.faction = { ...EMPTY_FACTION };
+
+    const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
+    if (pages.length > 0) {
+      try {
+        const data = JSON.parse(pages[0].text.content);
+        const faction = data.faction;
+        if (faction) {
+          this.faction = faction;
+        }
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          ui.notifications.error(game.i18n.localize("CHUD.errors.failedToParse"));
+        } else {
+          ui.notifications.error(game.i18n.localize("CHUD.errors.genericSheetError"));
+        }
+      }
+    }
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ["sheet", "journal-sheet"],
+      title: game.i18n.localize("CHUD.strings.conversationFactionEntry"),
+      id: "conversation-entry-sheet",
+      template: `modules/conversation-hud/templates/conversation_faction_sheet.hbs`,
+      width: 635,
+      height: "auto",
+      resizable: false,
+    });
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    // Check to see if the user is a GM, and if not, exit function early so as not to bind the listeners
+    if (!game.user.isGM) {
+      return;
+    }
+
+    const displayFactionToggle = html.find("[name=displayFaction]")[0];
+    displayFactionToggle.addEventListener("change", (event) => this.onToggleFactionDisplay(event));
+
+    const factionNameInput = html.find("[name=factionName]")[0];
+    factionNameInput.addEventListener("change", (event) => this.onUpdateFactionName(event));
+
+    const factionLogoInput = html.find("[name=factionImg]")[0];
+    factionLogoInput.addEventListener("change", (event) => this.onUpdateFactionLogo(event));
+
+    const factionBannerToggle = html.find("[name=displayFactionBanner]")[0];
+    factionBannerToggle.addEventListener("change", (event) => this.onToggleFactionBanner(event));
+
+    const factionBannerTintInput = html.find("[name=factionTint]")[0];
+    factionBannerTintInput.addEventListener("change", (event) => this.onUpdateBannerTint(event));
+
+    const factionBannerTintPicker = html.find("[name=factionTintPicker]")[0];
+    factionBannerTintPicker.addEventListener("change", (event) => this.onUpdateBannerTint(event));
+
+    // Activate banner shape buttons
+    const bannerShapeButtons = html.find(".banner-shape-button");
+    for (const button of bannerShapeButtons) {
+      const buttonId = button.getAttribute("id");
+      button.addEventListener("click", () => this.onUpdateBannerShape(buttonId));
+    }
+
+    html.find("#save-conversation-faction").click(async (_event) => this.#handleSaveConversation());
+  }
+
+  getData(options) {
+    const baseData = super.getData(options);
+
+    const data = {
+      isGM: game.user.isGM,
+      dirty: this.dirty,
+      faction: this.faction,
+      name: baseData.data.name,
+      data: baseData.data,
+    };
+
+    return data;
+  }
+
+  onToggleFactionDisplay(event) {
+    if (!event.target) return;
+
+    this.faction.displayFaction = event.target.checked;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  onUpdateFactionName(event) {
+    if (!event.target) return;
+
+    this.faction.factionName = event.target.value;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  onToggleFactionBanner(event) {
+    if (!event.target) return;
+
+    this.faction.factionBannerEnabled = event.target.checked;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  onUpdateFactionLogo(event) {
+    if (!event.target) return;
+
+    this.faction.factionLogo = event.target.value;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  async onUpdateBannerShape(selectedShapeId) {
+    this.faction.factionBannerShape = selectedShapeId;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  onUpdateBannerTint(event) {
+    if (!event.target) return;
+
+    this.faction.factionBannerTint = event.target.value;
+    this.dirty = true;
+    this.render(false);
+  }
+
+  async close(options) {
+    if (this.dirty) {
+      await getConfirmationFromUser(
+        "CHUD.dialogue.unsavedChanges",
+        this.#handleConfirmationClose.bind(this, true),
+        this.#handleConfirmationClose.bind(this, false),
+        '<i class="fas fa-save"></i>',
+        '<i class="fas fa-trash"></i>'
+      );
+    } else {
+      this.dirty = false;
+      Object.values(this.editors).forEach((editor) => {
+        if (editor.instance) {
+          editor.instance.destroy();
+        }
+      });
+    }
+
+    return super.close({ submit: false });
+  }
+
+  async #handleConfirmationClose(save) {
+    if (save) {
+      await this.#handleSaveConversation();
+    } else {
+      const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
+
+      if (pages.length === 0) {
+        this.faction = { ...EMPTY_FACTION };
+      } else {
+        const data = JSON.parse(pages[0].text.content);
+        const faction = data.faction;
+        if (faction) {
+          this.faction = faction;
+        }
+      }
+
+      this.dirty = false;
+    }
+  }
+
+  async #handleSaveConversation() {
+    // Get document pages
+    const pages = this.object.getEmbeddedCollection("JournalEntryPage").contents;
+    const dataToSave = {
+      faction: this.faction,
+    };
+
+    if (pages.length === 0) {
+      // Create a document entry page if none are present
+      await this.object.createEmbeddedDocuments("JournalEntryPage", [
+        {
+          text: { content: JSON.stringify(dataToSave) },
+          name: game.i18n.localize("CHUD.strings.factionData"),
+        },
+      ]);
+    } else {
+      // Otherwise, update the first (and realistically the only) entry page
+      pages[0].text.content = JSON.stringify(dataToSave);
+      await this.object.updateEmbeddedDocuments(
+        "JournalEntryPage",
+        [
+          {
+            _id: pages[0]._id,
+            name: pages[0].name,
+            type: pages[0].type,
+            text: { content: pages[0].text?.content || "", format: 1, markdown: undefined },
+            src: pages[0].src || "",
+            image: { caption: pages[0].image?.caption || "" },
+            video: pages[0].video,
+          },
+        ],
+        { render: false, renderSheet: false }
+      );
+    }
+
+    this.dirty = false;
+    this.render(false);
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -192,6 +192,10 @@
         "bottom": "Bottom"
       }
     },
+    "displayAllParticipantsToPlayers": {
+      "name": "Display Participants List",
+      "hint": "Toggle whether or not to display the list of all the conversation participants to the players. The GM will still be able to see this list."
+    },
     "enableSpeakAs": {
       "name": "Enable Speak As",
       "hint": "Toggle the Speak As feature on or off. By default, the feature is on, but if you do not use it and do not want an extra button to appear, you can toggle it off."

--- a/lang/en.json
+++ b/lang/en.json
@@ -42,7 +42,9 @@
     "sceneConversation": {
       "title": "Scene Conversation",
       "hint": "A linked conversation that will activate automatically whenever the scene is activated."
-    }
+    },
+
+    "sceneActors": "Actors in scene"
   },
 
   "CHUD.dialogue": {
@@ -91,7 +93,16 @@
       "clone": "Clone Participant",
       "edit": "Edit Participant",
       "delete": "Delete Participant"
-    }
+    },
+
+    "selection": {
+      "selectAll": "Select All",
+      "selectVisible": "Select Visible",
+      "deselectAll": "Deselect All"
+    },
+
+    "pullParticipants": "Pull Participants from Scene",
+    "addActors": "Add Actors"
   },
 
   "CHUD.tabs": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,7 @@
 
     "conversationEntry": "Conversation Entry",
     "participantData": "Conversation Participant Data",
+    "factionData": "Conversation Faction Data",
 
     "unsavedChanges": "Unsaved Changes",
     "unsavedChangesHint": "The conversation contains unsaved changes. Do you wish to save them?",
@@ -75,6 +76,8 @@
     "closeConversation": "Close Conversation",
 
     "saveConversation": "Save Conversation",
+    "saveFaction": "Save Faction",
+    "exportFaction": "Export Faction",
 
     "toggleSpeakAs": "Toggle Speak As",
     "toggleVisibility": "Toggle Visibility",
@@ -97,6 +100,10 @@
   },
 
   "CHUD.faction": {
+    "factionSelector": {
+      "name": "Faction Selector",
+      "hint": "Create a new faction or select an already existing one."
+    },
     "displayFaction": {
       "name": "Display Faction",
       "hint": "Toggle the display of the faction to which the participant belongs to."
@@ -130,7 +137,8 @@
   },
 
   "CHUD.sheets": {
-    "entrySheet": "Conversation Entry Sheet"
+    "entrySheet": "Conversation Entry Sheet",
+    "factionSheet": "Conversation Faction Sheet"
   },
 
   "CHUD.errors": {

--- a/templates/add_edit_participant.hbs
+++ b/templates/add_edit_participant.hbs
@@ -13,10 +13,39 @@
   {{!-- CONTENT --}}
   <div>
     {{!-- PARTICIPANT CONFIG TAB --}}
-    {{> "modules/conversation-hud/templates/fragments/participant_data_config_tab.hbs" participantName=participantName participantImg=participantImg}}
+    <div class="tab" data-tab="participant-config">
+      {{> "modules/conversation-hud/templates/fragments/participant_data_config_tab.hbs" participantName=participantName participantImg=participantImg}}
+    </div>
 
     {{!-- FACTION CONFIG TAB --}}
     <div class="tab" data-tab="faction-config">
+      {{!-- Saved factions select --}}
+      <div class="form-group">
+        <label>{{localize 'CHUD.faction.factionSelector.title'}}</label>
+        <div class="form-fields">
+          <select name="selectedFaction">
+            {{#select selectedFaction}}
+              <option value="">New Faction</option>
+              {{#each savedFactions}}
+                <option value="{{ this.id }}">{{ this.name }}</option>
+              {{/each}}
+            {{/select}}
+          </select>
+        </div>
+        <p class="notes">{{localize "CHUD.faction.factionSelector.hint"}}</p>
+      </div>
+
+      {{!-- Faction display toggle --}}
+      <div class="form-group">
+        <label>{{localize "CHUD.faction.displayFaction.name"}}</label>
+        <div class="form-fields">
+          <input type="checkbox" name="displayFaction" {{checked displayFaction}}>
+        </div>
+        <p class="notes">{{localize "CHUD.faction.displayFaction.hint"}}</p>
+      </div>
+
+      <hr>
+
       {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=displayFaction factionName=factionName factionLogo=factionLogo factionBannerEnabled=factionBannerEnabled factionBannerShape=factionBannerShape factionBannerTint=factionBannerTint}}
     </div>
  </div>

--- a/templates/add_edit_participant.hbs
+++ b/templates/add_edit_participant.hbs
@@ -14,7 +14,10 @@
   <div>
     {{!-- PARTICIPANT CONFIG TAB --}}
     <div class="tab" data-tab="participant-config">
-      {{> "modules/conversation-hud/templates/fragments/participant_data_config_tab.hbs" participantName=participantName participantImg=participantImg}}
+      {{> "modules/conversation-hud/templates/fragments/participant_data_config_tab.hbs"
+        participantName=participantName
+        participantImg=participantImg
+      }}
     </div>
 
     {{!-- FACTION CONFIG TAB --}}
@@ -46,7 +49,15 @@
 
       <hr>
 
-      {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=displayFaction factionName=factionName factionLogo=factionLogo factionBannerEnabled=factionBannerEnabled factionBannerShape=factionBannerShape factionBannerTint=factionBannerTint}}
+      {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs"
+        displayFaction=displayFaction
+        factionName=factionName
+        factionLogo=factionLogo
+        factionBannerEnabled=factionBannerEnabled
+        factionBannerShape=factionBannerShape
+        factionBannerTint=factionBannerTint
+        hasSelectedFaction=selectedFaction
+      }}
     </div>
  </div>
 

--- a/templates/add_edit_participant.hbs
+++ b/templates/add_edit_participant.hbs
@@ -16,8 +16,10 @@
     {{> "modules/conversation-hud/templates/fragments/participant_data_config_tab.hbs" participantName=participantName participantImg=participantImg}}
 
     {{!-- FACTION CONFIG TAB --}}
-    {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=displayFaction factionName=factionName factionLogo=factionLogo factionBannerEnabled=factionBannerEnabled factionBannerShape=factionBannerShape factionBannerTint=factionBannerTint}}
-  </div>
+    <div class="tab" data-tab="faction-config">
+      {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=displayFaction factionName=factionName factionLogo=factionLogo factionBannerEnabled=factionBannerEnabled factionBannerShape=factionBannerShape factionBannerTint=factionBannerTint}}
+    </div>
+ </div>
 
   {{!-- FOOTER --}}
   <footer class="sheet-footer flexrow">

--- a/templates/add_edit_participant.hbs
+++ b/templates/add_edit_participant.hbs
@@ -24,7 +24,7 @@
     <div class="tab" data-tab="faction-config">
       {{!-- Saved factions select --}}
       <div class="form-group">
-        <label>{{localize 'CHUD.faction.factionSelector.title'}}</label>
+        <label>{{localize 'CHUD.faction.factionSelector.name'}}</label>
         <div class="form-fields">
           <select name="selectedFaction">
             {{#select selectedFaction}}

--- a/templates/conversation.hbs
+++ b/templates/conversation.hbs
@@ -66,20 +66,22 @@
         </div>
       {{/each}}
     {{else}}
-      {{#each participants as |participant index|}}
-        <div class="conversation-participant-wrapper">
-          {{!-- Participant --}}
-          <div class="conversation-participant" data-tooltip="{{participant.name}}">
-            <img class="portrait {{../portraitAnchor}}" src="{{participant.img}}" alt="image" />
-            <p class="name">{{participant.name}}</p>
-          </div>
+      {{#if displayParticipantsToPlayers}}
+        {{#each participants as |participant index|}}
+          <div class="conversation-participant-wrapper">
+            {{!-- Participant --}}
+            <div class="conversation-participant" data-tooltip="{{participant.name}}">
+              <img class="portrait {{../portraitAnchor}}" src="{{participant.img}}" alt="image" />
+              <p class="name">{{participant.name}}</p>
+            </div>
 
-          {{!-- Faction wrapper --}}
-          <div data-tooltip="{{participant.faction.factionName}}" style="align-self: flex-start;">
-            {{> "modules/conversation-hud/templates/fragments/faction_wrapper.hbs" faction=participant.faction}}
+            {{!-- Faction wrapper --}}
+            <div data-tooltip="{{participant.faction.factionName}}" style="align-self: flex-start;">
+              {{> "modules/conversation-hud/templates/fragments/faction_wrapper.hbs" faction=participant.faction}}
+            </div>
           </div>
-        </div>
-      {{/each}}
+        {{/each}}
+      {{/if}}
     {{/if}}
     
     {{!-- GMs also have an add participant button that needs to be rendered inside the list --}}

--- a/templates/conversation_controls.hbs
+++ b/templates/conversation_controls.hbs
@@ -48,6 +48,14 @@
   {{/if}}
 
   <div
+    class="control-button"
+    onclick="game.ConversationHud.pullActorsFromScene()"
+    data-tooltip="{{localize 'CHUD.actions.pullParticipants'}}"
+  >
+    <i class="fas fa-up-from-bracket"></i>
+  </div>
+
+  <div
     class="control-button margin-top"
     onclick="game.ConversationHud.saveActiveConversation()"
     data-tooltip="{{localize 'CHUD.actions.saveConversation'}}"

--- a/templates/conversation_faction_sheet.hbs
+++ b/templates/conversation_faction_sheet.hbs
@@ -1,0 +1,20 @@
+<form class="flexcol conversation-faction-sheet" style="height: 100%">
+  <div id="conversation-sheet-content-wrapper" class="drag-and-drop-wrapper">
+    {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=faction.displayFaction factionName=faction.factionName factionLogo=faction.factionLogo factionBannerEnabled=faction.factionBannerEnabled factionBannerShape=faction.factionBannerShape factionBannerTint=faction.factionBannerTint}}
+  </div>
+
+  <div class="footer">
+    <footer class="sheet-footer flexrow">
+      <button
+        type="button"
+        name="save-conversation-faction"
+        id="save-conversation-faction"
+        title="{{localize 'CHUD.actions.saveFaction'}}"
+        {{#unless dirty}} disabled {{/unless}}
+      >
+        <i class="fas fa-save"></i>
+        {{localize 'CHUD.actions.saveFaction'}}
+      </button>
+    </footer>
+  </div>
+</form>

--- a/templates/conversation_faction_sheet.hbs
+++ b/templates/conversation_faction_sheet.hbs
@@ -1,4 +1,9 @@
 <form class="flexcol conversation-faction-sheet" style="height: 100%">
+  <div class="flexrow header">
+    <input name="name" type="text" value="{{name}}" placeholder="{{localize 'CHUD.strings.documentName'}}"/>
+  </div>
+
+
   <div id="conversation-sheet-content-wrapper" class="drag-and-drop-wrapper">
     {{> "modules/conversation-hud/templates/fragments/faction_data_config_tab.hbs" displayFaction=faction.displayFaction factionName=faction.factionName factionLogo=faction.factionLogo factionBannerEnabled=faction.factionBannerEnabled factionBannerShape=faction.factionBannerShape factionBannerTint=faction.factionBannerTint}}
   </div>

--- a/templates/conversation_input.hbs
+++ b/templates/conversation_input.hbs
@@ -1,6 +1,16 @@
-<form class="flexcol conversation-entry-sheet">
+<form class="flexcol conversation-entry-sheet" style="height: 100%">
   <div class="flexrow header">
     <p> {{localize 'CHUD.strings.currentParticipants'}} </p>
+
+    <button
+      type="button"
+      name="pull-participants-from-scene"
+      id="pull-participants-from-scene"
+      title="{{localize 'CHUD.actions.pullParticipants'}}"
+      class="header-action-button"
+    >
+      <i class="fas fa-up-from-bracket"></i>
+    </button>
           
     <button
       type="button"

--- a/templates/conversation_sheet.hbs
+++ b/templates/conversation_sheet.hbs
@@ -15,6 +15,16 @@
 
       <button
         type="button"
+        name="pull-participants-from-scene"
+        id="pull-participants-from-scene"
+        title="{{localize 'CHUD.actions.pullParticipants'}}"
+        class="header-action-button"
+      >
+        <i class="fas fa-up-from-bracket"></i>
+      </button>
+
+      <button
+        type="button"
         name="add-participant"
         id="add-participant"
         title="{{localize 'CHUD.actions.participant.add'}}"

--- a/templates/fragments/faction_data_config_tab.hbs
+++ b/templates/fragments/faction_data_config_tab.hbs
@@ -1,129 +1,142 @@
-<div class="tab" data-tab="faction-config">
-  {{!-- Faction display toggle --}}
-  <div class="form-group">
-    <label>{{localize "CHUD.faction.displayFaction.name"}}</label>
-    <div class="form-fields">
-      <input type="checkbox" name="displayFaction" {{checked displayFaction}}>
+{{!-- <div class="form-group">
+  <label>{{localize 'CHUD.faction.factionSelector.title'}}</label>
+  <div class="form-fields">
+    <select name="flags.conversation-hud.sceneConversation">
+      {{#select linkedConversation}}
+        <option value=""></option>
+        {{#each conversations}}
+          <option value="{{ this.id }}">{{ this.name }}</option>
+        {{/each}}
+      {{/select}}
+    </select>
+  </div>
+  <p class="notes">{{localize "CHUD.faction.factionSelector.hint"}}</p>
+</div> --}}
+
+{{!-- Faction display toggle --}}
+<div class="form-group">
+  <label>{{localize "CHUD.faction.displayFaction.name"}}</label>
+  <div class="form-fields">
+    <input type="checkbox" name="displayFaction" {{checked displayFaction}}>
+  </div>
+  <p class="notes">{{localize "CHUD.faction.displayFaction.hint"}}</p>
+</div>
+
+{{!-- Faction name --}}
+<div class="form-group">
+  <label>{{localize "CHUD.faction.factionName.name"}}</label>
+  <div class="form-fields">
+    <input class="text" type="text" name="factionName" placeholder="{{localize 'CHUD.faction.factionName.placeholder'}}" value="{{factionName}}" />
+  </div>
+  <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
+</div>
+
+<hr>
+
+<div class="banner-configuration">
+  {{!-- Banner config --}}
+  <div>
+    {{!-- Faction logo --}}
+    <div class="form-group">
+      <label>{{localize "CHUD.faction.factionLogo.name"}}</label>
+      <div class="form-fields">
+        <button type="button" class="file-picker" data-type="imagevideo" data-target="factionImg" title="{{localize 'CHUD.strings.browseFiles'}}">
+          <i class="fas fa-file-import fa-fw"></i>
+        </button>
+        <input class="image" type="text" name="factionImg" placeholder="{{localize 'CHUD.strings.filePath'}}" value="{{factionLogo}}" />
+      </div>
+      <p class="notes">{{localize "CHUD.faction.factionLogo.hint"}}</p>
     </div>
-    <p class="notes">{{localize "CHUD.faction.displayFaction.hint"}}</p>
+    
+    {{!-- Faction banner toggle --}}
+    <div class="form-group">
+      <label>{{localize "CHUD.faction.displayFactionBanner.name"}}</label>
+      <div class="form-fields">
+        <input type="checkbox" name="displayFactionBanner" {{checked factionBannerEnabled}}>
+      </div>
+      <p class="notes">{{localize "CHUD.faction.displayFactionBanner.hint"}}</p>
+    </div>
+
+    {{!-- Faction banner shape --}}
+    <div class="form-group">
+      <label>{{localize "CHUD.faction.factionBannerShape.name"}}</label>
+
+      <div class="banner-options">
+        <button id="shape-1" class="banner-shape-button {{#if (eq factionBannerShape "shape-1")}}active{{/if}}" type="button" name="shape-1">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color='#000000'}}
+        </button>
+
+        <button id="shape-2" class="banner-shape-button {{#if (eq factionBannerShape "shape-2")}}active{{/if}}" type="button" name="shape-2">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color='#000000'}}
+        </button>
+
+        <button id="shape-3" class="banner-shape-button {{#if (eq factionBannerShape "shape-3")}}active{{/if}}" type="button" name="shape-3">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color='#000000'}}
+        </button>
+
+        <button id="shape-4" class="banner-shape-button {{#if (eq factionBannerShape "shape-4")}}active{{/if}}" type="button" name="shape-4">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color='#000000'}}
+        </button>
+
+        <button id="shape-5" class="banner-shape-button {{#if (eq factionBannerShape "shape-5")}}active{{/if}}" type="button" name="shape-5">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color='#000000'}}
+        </button>
+
+        <button id="shape-6" class="banner-shape-button {{#if (eq factionBannerShape "shape-6")}}active{{/if}}" type="button" name="shape-6">
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color='#000000'}}
+        </button>
+      </div>
+    
+      <p class="notes">{{localize "CHUD.faction.factionBannerShape.hint"}}</p>
+    </div>
+
+    {{!-- Faction banner tint --}}
+    <div class="form-group">
+      <label>{{ localize "CHUD.faction.factionBannerColor.name" }}</label>
+      <div class="form-fields">
+        <input class="color" type="text" name="factionTint" value="{{factionBannerTint}}" />
+        <input type="color" name="factionTintPicker" value="{{factionBannerTint}}" data-edit="factionTint" />
+      </div>
+      <p class="notes">{{localize "CHUD.faction.factionBannerColor.hint"}}</p>
+    </div>
   </div>
 
-  {{!-- Faction name --}}
-  <div class="form-group">
-    <label>{{localize "CHUD.faction.factionName.name"}}</label>
-    <div class="form-fields">
-      <input class="text" type="text" name="factionName" placeholder="{{localize 'CHUD.faction.factionName.placeholder'}}" value="{{factionName}}" />
-    </div>
-    <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
-  </div>
+  {{!-- Banner preview --}}
+  <div class="banner-preview-wrapper">
+    <div id="banner-preview-image" class="banner-preview-image {{#if factionBannerEnabled}}has-banner{{/if}}">
+      {{#unless (or factionLogo factionBannerEnabled)}}
+        <p class="no-banner-preview-text">{{localize 'CHUD.faction.noBannerPreview'}}</p>
+      {{/unless}}
 
-  <hr>
-  
-  <div class="banner-configuration">
-    {{!-- Banner config --}}
-    <div>
-      {{!-- Faction logo --}}
-      <div class="form-group">
-        <label>{{localize "CHUD.faction.factionLogo.name"}}</label>
-        <div class="form-fields">
-          <button type="button" class="file-picker" data-type="imagevideo" data-target="factionImg" title="{{localize 'CHUD.strings.browseFiles'}}">
-            <i class="fas fa-file-import fa-fw"></i>
-          </button>
-          <input class="image" type="text" name="factionImg" placeholder="{{localize 'CHUD.strings.filePath'}}" value="{{factionLogo}}" />
-        </div>
-        <p class="notes">{{localize "CHUD.faction.factionLogo.hint"}}</p>
-      </div>
-      
-      {{!-- Faction banner toggle --}}
-      <div class="form-group">
-        <label>{{localize "CHUD.faction.displayFactionBanner.name"}}</label>
-        <div class="form-fields">
-          <input type="checkbox" name="displayFactionBanner" {{checked factionBannerEnabled}}>
-        </div>
-        <p class="notes">{{localize "CHUD.faction.displayFactionBanner.hint"}}</p>
-      </div>
+      <img id="banner-preview-logo" src="{{factionLogo}}" alt="Banner Preview Logo">
 
-      {{!-- Faction banner shape --}}
-      <div class="form-group">
-        <label>{{localize "CHUD.faction.factionBannerShape.name"}}</label>
-
-        <div class="banner-options">
-          <button id="shape-1" class="banner-shape-button {{#if (eq factionBannerShape "shape-1")}}active{{/if}}" type="button" name="shape-1">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color='#000000'}}
-          </button>
-
-          <button id="shape-2" class="banner-shape-button {{#if (eq factionBannerShape "shape-2")}}active{{/if}}" type="button" name="shape-2">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color='#000000'}}
-          </button>
-
-          <button id="shape-3" class="banner-shape-button {{#if (eq factionBannerShape "shape-3")}}active{{/if}}" type="button" name="shape-3">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color='#000000'}}
-          </button>
-
-          <button id="shape-4" class="banner-shape-button {{#if (eq factionBannerShape "shape-4")}}active{{/if}}" type="button" name="shape-4">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color='#000000'}}
-          </button>
-
-          <button id="shape-5" class="banner-shape-button {{#if (eq factionBannerShape "shape-5")}}active{{/if}}" type="button" name="shape-5">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color='#000000'}}
-          </button>
-
-          <button id="shape-6" class="banner-shape-button {{#if (eq factionBannerShape "shape-6")}}active{{/if}}" type="button" name="shape-6">
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color='#000000'}}
-          </button>
-        </div>
-      
-        <p class="notes">{{localize "CHUD.faction.factionBannerShape.hint"}}</p>
-      </div>
-
-      {{!-- Faction banner tint --}}
-      <div class="form-group">
-        <label>{{ localize "CHUD.faction.factionBannerColor.name" }}</label>
-        <div class="form-fields">
-          <input class="color" type="text" name="factionTint" value="{{factionBannerTint}}" />
-          <input type="color" name="factionTintPicker" value="{{factionBannerTint}}" data-edit="factionTint" />
-        </div>
-        <p class="notes">{{localize "CHUD.faction.factionBannerColor.hint"}}</p>
-      </div>
-    </div>
-
-    {{!-- Banner preview --}}
-    <div class="banner-preview-wrapper">
-      <div id="banner-preview-image" class="banner-preview-image {{#if factionBannerEnabled}}has-banner{{/if}}">
-        {{#unless (or factionLogo factionBannerEnabled)}}
-          <p class="no-banner-preview-text">{{localize 'CHUD.faction.noBannerPreview'}}</p>
-        {{/unless}}
-
-        <img id="banner-preview-logo" src="{{factionLogo}}" alt="Banner Preview Logo">
-
-        {{#if factionBannerEnabled}}
-          {{#if (eq factionBannerShape "shape-1")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color=factionBannerTint}}
-          {{/if}}
-
-          {{#if (eq factionBannerShape "shape-2")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color=factionBannerTint}}
-          {{/if}}
-
-          {{#if (eq factionBannerShape "shape-3")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color=factionBannerTint}}
-          {{/if}}
-
-          {{#if (eq factionBannerShape "shape-4")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color=factionBannerTint}}
-          {{/if}}
-
-          {{#if (eq factionBannerShape "shape-5")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color=factionBannerTint}}
-          {{/if}}
-
-          {{#if (eq factionBannerShape "shape-6")}}
-            {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color=factionBannerTint}}
-          {{/if}}
+      {{#if factionBannerEnabled}}
+        {{#if (eq factionBannerShape "shape-1")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color=factionBannerTint}}
         {{/if}}
-      </div>
 
-      <p>{{localize "CHUD.faction.bannerPreview"}}</p>
+        {{#if (eq factionBannerShape "shape-2")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color=factionBannerTint}}
+        {{/if}}
+
+        {{#if (eq factionBannerShape "shape-3")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color=factionBannerTint}}
+        {{/if}}
+
+        {{#if (eq factionBannerShape "shape-4")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color=factionBannerTint}}
+        {{/if}}
+
+        {{#if (eq factionBannerShape "shape-5")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color=factionBannerTint}}
+        {{/if}}
+
+        {{#if (eq factionBannerShape "shape-6")}}
+          {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color=factionBannerTint}}
+        {{/if}}
+      {{/if}}
     </div>
+
+    <p>{{localize "CHUD.faction.bannerPreview"}}</p>
   </div>
 </div>

--- a/templates/fragments/faction_data_config_tab.hbs
+++ b/templates/fragments/faction_data_config_tab.hbs
@@ -1,116 +1,193 @@
-{{!-- Faction name --}}
-<div class="form-group">
-  <label>{{localize "CHUD.faction.factionName.name"}}</label>
-  <div class="form-fields">
-    <input class="text" type="text" name="factionName" placeholder="{{localize 'CHUD.faction.factionName.placeholder'}}" value="{{factionName}}" />
-  </div>
-  <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
-</div>
-
-<div class="banner-configuration">
-  {{!-- Banner config --}}
-  <div>
-    {{!-- Faction logo --}}
-    <div class="form-group">
-      <label>{{localize "CHUD.faction.factionLogo.name"}}</label>
-      <div class="form-fields">
-        <button type="button" class="file-picker" data-type="imagevideo" data-target="factionImg" title="{{localize 'CHUD.strings.browseFiles'}}">
-          <i class="fas fa-file-import fa-fw"></i>
-        </button>
-        <input class="image" type="text" name="factionImg" placeholder="{{localize 'CHUD.strings.filePath'}}" value="{{factionLogo}}" />
-      </div>
-      <p class="notes">{{localize "CHUD.faction.factionLogo.hint"}}</p>
+<div class="{{#if hasSelectedFaction}}view-only{{/if}}">
+  {{!-- Faction name --}}
+  <div class="form-group">
+    <label>{{localize "CHUD.faction.factionName.name"}}</label>
+    <div class="form-fields">
+      <input
+        class="text"
+        type="text"
+        name="factionName"
+        placeholder="{{localize 'CHUD.faction.factionName.placeholder'}}"
+        value="{{factionName}}"
+        {{#if hasSelectedFaction}}disabled{{/if}}
+      />
     </div>
-    
-    {{!-- Faction banner toggle --}}
-    <div class="form-group">
-      <label>{{localize "CHUD.faction.displayFactionBanner.name"}}</label>
-      <div class="form-fields">
-        <input type="checkbox" name="displayFactionBanner" {{checked factionBannerEnabled}}>
-      </div>
-      <p class="notes">{{localize "CHUD.faction.displayFactionBanner.hint"}}</p>
-    </div>
-
-    {{!-- Faction banner shape --}}
-    <div class="form-group">
-      <label>{{localize "CHUD.faction.factionBannerShape.name"}}</label>
-
-      <div class="banner-options">
-        <button id="shape-1" class="banner-shape-button {{#if (eq factionBannerShape "shape-1")}}active{{/if}}" type="button" name="shape-1">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color='#000000'}}
-        </button>
-
-        <button id="shape-2" class="banner-shape-button {{#if (eq factionBannerShape "shape-2")}}active{{/if}}" type="button" name="shape-2">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color='#000000'}}
-        </button>
-
-        <button id="shape-3" class="banner-shape-button {{#if (eq factionBannerShape "shape-3")}}active{{/if}}" type="button" name="shape-3">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color='#000000'}}
-        </button>
-
-        <button id="shape-4" class="banner-shape-button {{#if (eq factionBannerShape "shape-4")}}active{{/if}}" type="button" name="shape-4">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color='#000000'}}
-        </button>
-
-        <button id="shape-5" class="banner-shape-button {{#if (eq factionBannerShape "shape-5")}}active{{/if}}" type="button" name="shape-5">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color='#000000'}}
-        </button>
-
-        <button id="shape-6" class="banner-shape-button {{#if (eq factionBannerShape "shape-6")}}active{{/if}}" type="button" name="shape-6">
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color='#000000'}}
-        </button>
-      </div>
-    
-      <p class="notes">{{localize "CHUD.faction.factionBannerShape.hint"}}</p>
-    </div>
-
-    {{!-- Faction banner tint --}}
-    <div class="form-group">
-      <label>{{ localize "CHUD.faction.factionBannerColor.name" }}</label>
-      <div class="form-fields">
-        <input class="color" type="text" name="factionTint" value="{{factionBannerTint}}" />
-        <input type="color" name="factionTintPicker" value="{{factionBannerTint}}" data-edit="factionTint" />
-      </div>
-      <p class="notes">{{localize "CHUD.faction.factionBannerColor.hint"}}</p>
-    </div>
+    <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
   </div>
 
-  {{!-- Banner preview --}}
-  <div class="banner-preview-wrapper">
-    <div id="banner-preview-image" class="banner-preview-image {{#if factionBannerEnabled}}has-banner{{/if}}">
-      {{#unless (or factionLogo factionBannerEnabled)}}
-        <p class="no-banner-preview-text">{{localize 'CHUD.faction.noBannerPreview'}}</p>
-      {{/unless}}
+  <div class="banner-configuration">
+    {{!-- Banner config --}}
+    <div>
+      {{!-- Faction logo --}}
+      <div class="form-group">
+        <label>{{localize "CHUD.faction.factionLogo.name"}}</label>
+        <div class="form-fields">
+          <button
+            type="button"
+            class="file-picker"
+            data-type="imagevideo"
+            data-target="factionImg"
+            title="{{localize 'CHUD.strings.browseFiles'}}"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+            <i class="fas fa-file-import fa-fw"></i>
+          </button>
 
-      <img id="banner-preview-logo" src="{{factionLogo}}" alt="Banner Preview Logo">
+          <input
+            class="image"
+            type="text"
+            name="factionImg"
+            placeholder="{{localize 'CHUD.strings.filePath'}}"
+            value="{{factionLogo}}"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          />
+        </div>
+        <p class="notes">{{localize "CHUD.faction.factionLogo.hint"}}</p>
+      </div>
+      
+      {{!-- Faction banner toggle --}}
+      <div class="form-group">
+        <label>{{localize "CHUD.faction.displayFactionBanner.name"}}</label>
+        <div class="form-fields">
+          <input
+            type="checkbox"
+            name="displayFactionBanner"
+            {{checked factionBannerEnabled}}
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+        </div>
+        <p class="notes">{{localize "CHUD.faction.displayFactionBanner.hint"}}</p>
+      </div>
 
-      {{#if factionBannerEnabled}}
-        {{#if (eq factionBannerShape "shape-1")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color=factionBannerTint}}
-        {{/if}}
+      {{!-- Faction banner shape --}}
+      <div class="form-group">
+        <label>{{localize "CHUD.faction.factionBannerShape.name"}}</label>
 
-        {{#if (eq factionBannerShape "shape-2")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color=factionBannerTint}}
-        {{/if}}
+        <div class="banner-options">
+          <button
+            id="shape-1"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-1")}}active{{/if}}"
+            type="button"
+            name="shape-1"
+            {{#if hasSelectedFaction}}disabled{{/if}}  
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color='#000000'}}
+          </button>
 
-        {{#if (eq factionBannerShape "shape-3")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color=factionBannerTint}}
-        {{/if}}
+          <button
+            id="shape-2"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-2")}}active{{/if}}"
+            type="button"
+            name="shape-2"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color='#000000'}}
+          </button>
 
-        {{#if (eq factionBannerShape "shape-4")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color=factionBannerTint}}
-        {{/if}}
+          <button
+            id="shape-3"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-3")}}active{{/if}}"
+            type="button"
+            name="shape-3"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color='#000000'}}
+          </button>
 
-        {{#if (eq factionBannerShape "shape-5")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color=factionBannerTint}}
-        {{/if}}
+          <button
+            id="shape-4"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-4")}}active{{/if}}"
+            type="button"
+            name="shape-4"
+            {{#if hasSelectedFaction}}disabled{{/if}}  
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color='#000000'}}
+          </button>
 
-        {{#if (eq factionBannerShape "shape-6")}}
-          {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color=factionBannerTint}}
-        {{/if}}
-      {{/if}}
+          <button
+            id="shape-5"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-5")}}active{{/if}}"
+            type="button"
+            name="shape-5"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color='#000000'}}
+          </button>
+
+          <button
+            id="shape-6"
+            class="banner-shape-button {{#if (eq factionBannerShape "shape-6")}}active{{/if}}"
+            type="button"
+            name="shape-6"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          >
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color='#000000'}}
+          </button>
+        </div>
+      
+        <p class="notes">{{localize "CHUD.faction.factionBannerShape.hint"}}</p>
+      </div>
+
+      {{!-- Faction banner tint --}}
+      <div class="form-group">
+        <label>{{ localize "CHUD.faction.factionBannerColor.name" }}</label>
+        <div class="form-fields">
+          <input
+            class="color"
+            type="text"
+            name="factionTint"
+            value="{{factionBannerTint}}"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          />
+          <input
+            type="color"
+            name="factionTintPicker"
+            value="{{factionBannerTint}}"
+            data-edit="factionTint"
+            {{#if hasSelectedFaction}}disabled{{/if}}
+          />
+        </div>
+        <p class="notes">{{localize "CHUD.faction.factionBannerColor.hint"}}</p>
+      </div>
     </div>
 
-    <p>{{localize "CHUD.faction.bannerPreview"}}</p>
+    {{!-- Banner preview --}}
+    <div class="banner-preview-wrapper">
+      <div id="banner-preview-image" class="banner-preview-image {{#if factionBannerEnabled}}has-banner{{/if}}">
+        {{#unless (or factionLogo factionBannerEnabled)}}
+          <p class="no-banner-preview-text">{{localize 'CHUD.faction.noBannerPreview'}}</p>
+        {{/unless}}
+
+        <img id="banner-preview-logo" src="{{factionLogo}}" alt="Banner Preview Logo">
+
+        {{#if factionBannerEnabled}}
+          {{#if (eq factionBannerShape "shape-1")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color=factionBannerTint}}
+          {{/if}}
+
+          {{#if (eq factionBannerShape "shape-2")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color=factionBannerTint}}
+          {{/if}}
+
+          {{#if (eq factionBannerShape "shape-3")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color=factionBannerTint}}
+          {{/if}}
+
+          {{#if (eq factionBannerShape "shape-4")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color=factionBannerTint}}
+          {{/if}}
+
+          {{#if (eq factionBannerShape "shape-5")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color=factionBannerTint}}
+          {{/if}}
+
+          {{#if (eq factionBannerShape "shape-6")}}
+            {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color=factionBannerTint}}
+          {{/if}}
+        {{/if}}
+      </div>
+
+      <p>{{localize "CHUD.faction.bannerPreview"}}</p>
+    </div>
   </div>
 </div>

--- a/templates/fragments/faction_data_config_tab.hbs
+++ b/templates/fragments/faction_data_config_tab.hbs
@@ -11,6 +11,17 @@
         value="{{factionName}}"
         {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
       />
+
+      {{#unless hasSelectedFaction}}
+        <button
+          type="button"
+          id="exportFaction"
+          name="exportFaction"
+          title="{{localize 'CHUD.actions.exportFaction'}}"
+        >
+          <i class="fa fa-save"></i>
+        </button>
+      {{/unless}}
     </div>
     <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
   </div>

--- a/templates/fragments/faction_data_config_tab.hbs
+++ b/templates/fragments/faction_data_config_tab.hbs
@@ -9,7 +9,7 @@
         name="factionName"
         placeholder="{{localize 'CHUD.faction.factionName.placeholder'}}"
         value="{{factionName}}"
-        {{#if hasSelectedFaction}}disabled{{/if}}
+        {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
       />
     </div>
     <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
@@ -28,7 +28,7 @@
             data-type="imagevideo"
             data-target="factionImg"
             title="{{localize 'CHUD.strings.browseFiles'}}"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
             <i class="fas fa-file-import fa-fw"></i>
           </button>
@@ -39,7 +39,7 @@
             name="factionImg"
             placeholder="{{localize 'CHUD.strings.filePath'}}"
             value="{{factionLogo}}"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           />
         </div>
         <p class="notes">{{localize "CHUD.faction.factionLogo.hint"}}</p>
@@ -53,7 +53,7 @@
             type="checkbox"
             name="displayFactionBanner"
             {{checked factionBannerEnabled}}
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
         </div>
         <p class="notes">{{localize "CHUD.faction.displayFactionBanner.hint"}}</p>
@@ -69,7 +69,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-1")}}active{{/if}}"
             type="button"
             name="shape-1"
-            {{#if hasSelectedFaction}}disabled{{/if}}  
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}  
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-1.hbs" color='#000000'}}
           </button>
@@ -79,7 +79,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-2")}}active{{/if}}"
             type="button"
             name="shape-2"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-2.hbs" color='#000000'}}
           </button>
@@ -89,7 +89,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-3")}}active{{/if}}"
             type="button"
             name="shape-3"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-3.hbs" color='#000000'}}
           </button>
@@ -99,7 +99,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-4")}}active{{/if}}"
             type="button"
             name="shape-4"
-            {{#if hasSelectedFaction}}disabled{{/if}}  
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}  
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-4.hbs" color='#000000'}}
           </button>
@@ -109,7 +109,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-5")}}active{{/if}}"
             type="button"
             name="shape-5"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-5.hbs" color='#000000'}}
           </button>
@@ -119,7 +119,7 @@
             class="banner-shape-button {{#if (eq factionBannerShape "shape-6")}}active{{/if}}"
             type="button"
             name="shape-6"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           >
             {{> "modules/conversation-hud/templates/banner-shapes/shape-6.hbs" color='#000000'}}
           </button>
@@ -137,14 +137,14 @@
             type="text"
             name="factionTint"
             value="{{factionBannerTint}}"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           />
           <input
             type="color"
             name="factionTintPicker"
             value="{{factionBannerTint}}"
             data-edit="factionTint"
-            {{#if hasSelectedFaction}}disabled{{/if}}
+            {{#if hasSelectedFaction}}tabindex="-1"{{/if}}
           />
         </div>
         <p class="notes">{{localize "CHUD.faction.factionBannerColor.hint"}}</p>

--- a/templates/fragments/faction_data_config_tab.hbs
+++ b/templates/fragments/faction_data_config_tab.hbs
@@ -1,27 +1,3 @@
-{{!-- <div class="form-group">
-  <label>{{localize 'CHUD.faction.factionSelector.title'}}</label>
-  <div class="form-fields">
-    <select name="flags.conversation-hud.sceneConversation">
-      {{#select linkedConversation}}
-        <option value=""></option>
-        {{#each conversations}}
-          <option value="{{ this.id }}">{{ this.name }}</option>
-        {{/each}}
-      {{/select}}
-    </select>
-  </div>
-  <p class="notes">{{localize "CHUD.faction.factionSelector.hint"}}</p>
-</div> --}}
-
-{{!-- Faction display toggle --}}
-<div class="form-group">
-  <label>{{localize "CHUD.faction.displayFaction.name"}}</label>
-  <div class="form-fields">
-    <input type="checkbox" name="displayFaction" {{checked displayFaction}}>
-  </div>
-  <p class="notes">{{localize "CHUD.faction.displayFaction.hint"}}</p>
-</div>
-
 {{!-- Faction name --}}
 <div class="form-group">
   <label>{{localize "CHUD.faction.factionName.name"}}</label>
@@ -30,8 +6,6 @@
   </div>
   <p class="notes">{{localize "CHUD.faction.factionName.hint"}}</p>
 </div>
-
-<hr>
 
 <div class="banner-configuration">
   {{!-- Banner config --}}

--- a/templates/fragments/participant_data_config_tab.hbs
+++ b/templates/fragments/participant_data_config_tab.hbs
@@ -1,28 +1,26 @@
-<div class="tab" data-tab="participant-config">
-  <div class="form-group">
-    <label>{{localize "CHUD.strings.name"}}</label>
-    <div class="form-fields">
-      <input class="text" type="text" name="participantName" placeholder="{{localize 'CHUD.strings.newParticipant'}}" value="{{participantName}}" />
-    </div>
-    <p class="notes">{{localize "CHUD.strings.nameHint"}}</p>
+<div class="form-group">
+  <label>{{localize "CHUD.strings.name"}}</label>
+  <div class="form-fields">
+    <input class="text" type="text" name="participantName" placeholder="{{localize 'CHUD.strings.newParticipant'}}" value="{{participantName}}" />
   </div>
+  <p class="notes">{{localize "CHUD.strings.nameHint"}}</p>
+</div>
 
-  <div class="form-group">
-    <label>{{localize "CHUD.strings.portrait"}}</label>
-    <div class="form-fields">
-      <button type="button" class="file-picker" data-type="imagevideo" data-target="participantImg" title="{{localize 'CHUD.strings.browseFiles'}}">
-        <i class="fas fa-file-import fa-fw"></i>
-      </button>
-      <input class="image" type="text" name="participantImg" placeholder="{{localize 'CHUD.strings.filePath'}}" value="{{participantImg}}" />
-    </div>
-    <p class="notes">{{localize "CHUD.strings.portraitHint"}}</p>
+<div class="form-group">
+  <label>{{localize "CHUD.strings.portrait"}}</label>
+  <div class="form-fields">
+    <button type="button" class="file-picker" data-type="imagevideo" data-target="participantImg" title="{{localize 'CHUD.strings.browseFiles'}}">
+      <i class="fas fa-file-import fa-fw"></i>
+    </button>
+    <input class="image" type="text" name="participantImg" placeholder="{{localize 'CHUD.strings.filePath'}}" value="{{participantImg}}" />
   </div>
+  <p class="notes">{{localize "CHUD.strings.portraitHint"}}</p>
+</div>
 
-  <div class="form-group">
-    <label>{{localize "CHUD.strings.linkedJournal"}}</label>
-    <select name="linkedJournal">
-      {{ selectOptions journals selected=linkedJournal blank="" nameAttr="id" labelAttr="name"}}
-    </select>
-    <p class="notes">{{localize "CHUD.strings.linkedJournalHint"}}</p>
-  </div>
+<div class="form-group">
+  <label>{{localize "CHUD.strings.linkedJournal"}}</label>
+  <select name="linkedJournal">
+    {{ selectOptions journals selected=linkedJournal blank="" nameAttr="id" labelAttr="name"}}
+  </select>
+  <p class="notes">{{localize "CHUD.strings.linkedJournalHint"}}</p>
 </div>

--- a/templates/pull_participants.hbs
+++ b/templates/pull_participants.hbs
@@ -1,0 +1,78 @@
+<form class="flexcol pull-participants-from-scene-form" style="height: 100%">
+  <div class="flexrow header">
+    <p> {{localize 'CHUD.strings.sceneActors'}} </p>
+
+    <button
+      type="button"
+      name="deselect-all"
+      id="deselect-all"
+      title="{{localize 'CHUD.actions.selection.deselectAll'}}"
+      class="header-action-button"
+    >
+      <i class="fa-regular fa-square"></i>
+    </button>
+
+    <button
+      type="button"
+      name="select-visible"
+      id="select-visible"
+      title="{{localize 'CHUD.actions.selection.selectVisible'}}"
+      class="header-action-button"
+    >
+      <i class="fa-regular fa-square-minus"></i>
+    </button>
+          
+    <button
+      type="button"
+      name="select-all"
+      id="select-all"
+      title="{{localize 'CHUD.actions.selection.selectAll'}}"
+      class="header-action-button"
+    >
+      <i class="fa-regular fa-square-check"></i>
+    </button>
+  </div>
+
+  {{!-- Actors pulled from current scene --}}
+  <div class="list-wrapper">
+    <div id="participants-pulled-from-scene">
+      {{#each participants as |participant index|}}
+        <div class="pulled-participant">
+          <div class="portrait-wrapper">
+            <img src="{{participant.img}}"/>
+          </div>
+
+          <div class="text-wrapper">
+            <p class="name">{{participant.name}}</p>
+            {{#if participant.hidden}}
+              <div class="is-hidden">
+                <i class="fa-regular fa-eye-slash"></i>
+                <p>Token is hidden</p>
+              </div>
+            {{/if}}
+          </div>
+
+          <input
+            id="pull-participant-checkbox"
+            class="pull-participant-checkbox"
+            type="checkbox"
+            {{#if participant.checked}}checked="checked"{{/if}}
+          >
+        </div>
+      {{/each}}
+    </div>
+  </div>
+
+  <div class="footer">
+    <footer class="sheet-footer flexrow">
+      <button
+        type="submit"
+        name="submit"
+        title="{{localize 'CHUD.actions.startConversation'}}"
+      >
+        <i class="fa fa-plus"></i>
+        {{localize 'CHUD.actions.addActors'}}
+      </button>
+    </footer>
+  </div>
+</form>


### PR DESCRIPTION
- Added a new sheet used for CHUD factions. You can now save created factions into their respective sheets, which can then be assigned to conversation participants. This means you can now create a faction, save it, and then easily assign it to multiple participants using the _Faction Selector_ dropdown found in the _Faction Config_ tab.
- Added the option to pull scene actors into a conversation. By using the _Pull Participants from Scene_ button, you can select which actors are present in the current scene to pull into the conversation.
- Added the option to hide the conversation participants list for the players, who will only be able to see the currently active speaker. This feature can be toggled on or off in the module settings.
- Fixed the missing message type when using the _Speak As_ feature.
- Small UI improvements and fixes.