### PR TITLE
Add auto portrait style

### DIFF
--- a/css/active-conversation/module-settings.css
+++ b/css/active-conversation/module-settings.css
@@ -17,6 +17,12 @@
   max-width: 620px;
   aspect-ratio: 1/1;
 }
+
+.conversation-hud-content .active-participant.auto .portrait {
+  position: relative;
+  max-width: min(620px, 30vw, 50vh);
+  max-height: min(620px, 30vw, 50vh);
+}
 /* #endregion */
 
 /* ----- Active participant portrait types when conversation is minimized ----- */
@@ -34,6 +40,15 @@
 .conversation-hud-wrapper.minimized .conversation-hud-content .active-participant.square {
   height: 124px;
   width: 124px;
+}
+
+.conversation-hud-wrapper.minimized .conversation-hud-content .active-participant.auto {
+  height: unset;
+  width: unset;
+}
+.conversation-hud-wrapper.minimized .conversation-hud-content .active-participant.auto .portrait {
+  max-height: 186px;
+  max-width: 220px;
 }
 /* #endregion */
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -28,6 +28,7 @@ export function registerSettings() {
       vertical: game.i18n.localize(`CHUD.settings.portraitStyle.choices.vertical`),
       horizontal: game.i18n.localize(`CHUD.settings.portraitStyle.choices.horizontal`),
       square: game.i18n.localize(`CHUD.settings.portraitStyle.choices.square`),
+      auto: game.i18n.localize(`CHUD.settings.portraitStyle.choices.auto`)
     },
   });
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -224,7 +224,8 @@
       "choices": {
         "vertical": "Vertical",
         "horizontal": "Horizontal",
-        "square": "Square"
+        "square": "Square",
+        "auto": "Auto"
       }
     },
     "portraitAnchorVertical": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -224,7 +224,8 @@
       "choices": {
         "vertical": "Vertical",
         "horizontal": "Horizontal",
-        "square": "Carré"
+        "square": "Carré",
+        "auto": "Auto"
       }
     },
     "portraitAnchorVertical": {


### PR DESCRIPTION
This adds another portrait style that is agnostic to any aspect ratio, does not upscale, and simply fits the box to the images that are being provided. The maximum width and height are capped to the union of the other styles.