### PR TITLE
Release 5.6.1

### DIFF
--- a/js/conversation.js
+++ b/js/conversation.js
@@ -324,6 +324,10 @@ export class ConversationHud {
     if (checkIfUserGM() && checkIfConversationActive()) {
       game.ConversationHud.conversationIsVisible = !game.ConversationHud.conversationIsVisible;
       socket.executeForEveryone("setConversationHudVisibility", game.ConversationHud.conversationIsVisible);
+
+      if (game.settings.get(MODULE_NAME, ModuleSettings.clearActiveParticipantOnVisibilityChange)) {
+        game.ConversationHud.changeActiveParticipant(-1);
+      }
     }
   }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -9,6 +9,7 @@ export const ModuleSettings = {
   enableMinimize: "enableMinimize",
   keepMinimize: "keepMinimize",
   enableSpeakAs: "enableSpeakAs",
+  clearActiveParticipantOnVisibilityChange: "clearActiveParticipantOnVisibilityChange",
   enableSceneConversations: "enableSceneConversations",
   blurAmount: "blurAmount",
   activeParticipantFontSize: "activeParticipantFontSize",
@@ -109,6 +110,16 @@ export function registerSettings() {
     scope: "world",
     config: true,
     requiresReload: false,
+    type: Boolean,
+    default: false,
+  });
+
+  game.settings.register(MODULE_NAME, ModuleSettings.clearActiveParticipantOnVisibilityChange, {
+    name: game.i18n.localize(`CHUD.settings.clearActiveParticipantOnVisibilityChange.name`),
+    hint: game.i18n.localize(`CHUD.settings.clearActiveParticipantOnVisibilityChange.hint`),
+    scope: "world",
+    config: true,
+    requiresReload: true,
     type: Boolean,
     default: false,
   });

--- a/lang/en.json
+++ b/lang/en.json
@@ -305,6 +305,10 @@
       "name": "Remember Minimization",
       "hint": "Remember minimization status between different conversations. By default, the feature is off so that every new conversation will start maximized. Enable this feature to have new conversations pick up the previous minimization state. Minimization state resets on page reload."
     },
+    "clearActiveParticipantOnVisibilityChange": {
+      "name": "Clear Active Participant on Visibility Change",
+      "hint": "Toggle whether or not to clear the currently active participant whenever the conversation visibility is toggled off."
+    },
     "enableSceneConversations": {
       "name": "Enable Scene Conversations",
       "hint": "Toggle the Scene Conversation feature on or off. By default, the feature is on and it allows users to link a conversation to a scene and when the scene is activated the conversation will open automatically. The conversation selector can be found on the Ambience tab of the Scene Config Sheet. If you do not want this behavior, you can toggle the feature off."
@@ -329,7 +333,7 @@
       "veryLarge": "Very Large"
     },
     "rpgUiFix": {
-      "name": "Enable custom UI fix",
+      "name": "Enable Custom UI Fix",
       "hint": "If you are using a module that changes the look of the UI and you are experiencing an issue which makes the sidebar overlap the conversation interface or the control buttons, enabling this feature should fix the issues."
     }
   }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -305,6 +305,10 @@
       "name": "Remember Minimization",
       "hint": "Remember minimization status between different conversations. By default, the feature is off so that every new conversation will start maximized. Enable this feature to have new conversations pick up the previous minimization state. Minimization state resets on page reload."
     },
+    "clearActiveParticipantOnVisibilityChange": {
+      "name": "Clear Active Participant on Visibility Change",
+      "hint": "Toggle whether or not to clear the currently active participant whenever the conversation visibility is toggled off."
+    },
     "enableSceneConversations": {
       "name": "Activer les Conversations de Scène",
       "hint": "Basculer la fonctionnalité Conversation de Scène on ou off. Par défaut, la fonctionnalité est activée et elle permet aux utilisateurs de lier une conversation à une scène et lorsque la scène est activée, la conversation s'ouvrira automatiquement. Le sélecteur de conversation se trouve sur l'onglet Ambiance de la Feuille de Configuration de Scène. Si vous ne souhaitez pas ce comportement, vous pouvez désactiver la fonctionnalité."


### PR DESCRIPTION
- Added setting for clearing currently active participant whenever the conversation visibility is toggled off.
- Fixed a bug that caused the conversation background change and background toggle to be reflected only on the client that trigger said changes.